### PR TITLE
Fix namespace creation order

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repository hosts the CSI KubeVirt driver and all of its build and dependent
 ## Deployment
 //TODO WIP
 - use `deploy/infra-cluster-service-account.yaml` to create a service account in kubevirt cluster (use '-n' flag in create command for specifying the kubevirt cluster namepsace)
+- Create namespace for the driver in tenant cluster
+    - Use `deploy/000-namespace.yaml`
 - use `deploy/secret.yaml` for creating the necessary secret in the tenant cluster
     - set apiUrl: [base64 of infra cluster API URL. E.g. base64 of https://cluster.mydomain.co:6443]
     - set service-ca.crt : copy value from token of infra service account created in previous section
@@ -17,7 +19,6 @@ This repository hosts the CSI KubeVirt driver and all of its build and dependent
     - set token : copy value from token of infra service account created in previous section
 - deploy files under `deploy` in  tenant cluster
     - 000-csi-driver.yaml
-    - 000-namespace.yaml
     - 020-authorization.yaml
     - 030-node.yaml
     - 040-controller.yaml

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ This repository hosts the CSI KubeVirt driver and all of its build and dependent
     - 030-node.yaml
     - 040-controller.yaml
 - create StorageClass and PersistentVolumeClaim - see `deploy/example`
-    
+- Enable HotplugVolumes feature gate
+    - In case your Kubevirt namespace has the ConfigMap 'kubevirt-config' then use `deploy/example/kubevirt-config.yaml` for adding the feature gate to it. Look at the path {.data.feature-gates}
+    - Otherwise, add the feature gate to the resource of type Kubevirt. There should be a single resource of this type and its name is irrelevant. See `deploy/example/kubevirt.yaml`
+    - Pay attention that in some deployments there are operators that will restore previous configuration. You will have to stop these operators for editing the resources. E.g. hco-operator in HCO.
+
 ## Examples
 
 ## Building the binaries

--- a/deploy/example/kubevirt-config.yaml
+++ b/deploy/example/kubevirt-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  default-network-interface: masquerade
+  feature-gates: DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Sidecar,Snapshot,HotplugVolumes
+  selinuxLauncherType: virt_launcher.process
+  smbios: |-
+    Family: KubeVirt
+    Manufacturer: KubeVirt
+    Product: None
+kind: ConfigMap
+metadata:
+  name: kubevirt-config
+  namespace: kubevirt

--- a/deploy/example/kubevirt.yaml
+++ b/deploy/example/kubevirt.yaml
@@ -1,0 +1,27 @@
+apiVersion: kubevirt.io/v1alpha3
+kind: KubeVirt
+metadata:
+  name: kubevirt
+  namespace: kubevirt
+spec:
+  certificateRotateStrategy: {}
+  configuration:
+    developerConfiguration:
+      featureGates:
+      - DataVolumes
+      - SRIOV
+      - LiveMigration
+      - CPUManager
+      - CPUNodeDiscovery
+      - Sidecar
+      - Snapshot
+      - HotplugVolumes
+    network:
+      defaultNetworkInterface: masquerade
+    smbios:
+      family: KubeVirt
+      manufacturer: KubeVirt
+      product: None
+      selinuxLauncherType: virt_launcher.process
+  customizeComponents: {}
+  uninstallStrategy: BlockUninstallIfWorkloadsExist


### PR DESCRIPTION
Merge after PR #15 

Namespace creation should be first step in tenant cluster.
Only then we can create the secret used by the driver.
Deploying the namespace YAML along with the driver is not needed.