### PR TITLE
Use kubeconfig instead of token and add ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ This repository hosts the CSI KubeVirt driver and all of its build and dependent
 ## Deployment
 //TODO WIP
 - use `deploy/infra-cluster-service-account.yaml` to create a service account in kubevirt cluster (use '-n' flag in create command for specifying the kubevirt cluster namepsace)
-- Create namespace for the driver in tenant cluster
+- create kubeconfig for service account
+    - Use `deploy/example/infracluster-kubeconfig.yaml` as a reference. Inside the file there are instructions for fields that need to be edited.
+    - Test your kubeconfig. Try listing resources of type VMI in the kubevirt cluster namepsace.
+- create namespace for the driver in tenant cluster
     - Use `deploy/000-namespace.yaml`
 - use `deploy/secret.yaml` for creating the necessary secret in the tenant cluster
-    - set apiUrl: [base64 of infra cluster API URL. E.g. base64 of https://cluster.mydomain.co:6443]
-    - set service-ca.crt : copy value from token of infra service account created in previous section
-    - set namespace: copy value from token of infra service account created in previous section
-    - set token : copy value from token of infra service account created in previous section
+    - set kubeconfig: [base64 of kubeconfig from previous step]
+- use `deploy/configmap.yaml` for creating the driver's config
+    - set infraClusterNamespace to the kubevirt cluster namepsace.
 - deploy files under `deploy` in  tenant cluster
     - 000-csi-driver.yaml
     - 020-authorization.yaml

--- a/deploy/020-autorization.yaml
+++ b/deploy/020-autorization.yaml
@@ -10,32 +10,6 @@ metadata:
   name: kubevirt-csi-controller-sa
   namespace: kubevirt-csi-driver
 ---
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kubevirt-csi-controller-provisioner-binding
-subjects:
-  - kind: ServiceAccount
-    name: kubevirt-csi-controller-sa
-    namespace: kubevirt-csi-driver
-roleRef:
-  kind: ClusterRole
-  name: csi-external-provisioner
-  apiGroup: rbac.authorization.k8s.io
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kubevirt-csi-controller-attacher-binding
-subjects:
-  - kind: ServiceAccount
-    name: kubevirt-csi-controller-sa
-    namespace: kubevirt-csi-driver
-roleRef:
-  kind: ClusterRole
-  name: csi-external-attacher
-  apiGroup: rbac.authorization.k8s.io
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -91,8 +65,6 @@ rules:
     resources: ["securitycontextconstraints"]
     verbs: ["use"]
     resourceNames: ["privileged"]
----
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/030-node.yaml
+++ b/deploy/030-node.yaml
@@ -32,9 +32,7 @@ spec:
             - "--namespace=kubevirt-csi-driver"
             - "--node-name=$(KUBE_NODE_NAME)"
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"
-            - "--infra-cluster-api-url=$(INFRACLUSTER_API_URL)"
-            - "--infra-cluster-token=/var/run/secrets/infracluster/token"
-            - "--infra-cluster-ca=/var/run/secrets/infracluster/service-ca.crt"
+            - "--infra-cluster-kubeconfig=/var/run/secrets/infracluster/kubeconfig"
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -42,14 +40,9 @@ spec:
                   fieldPath: spec.nodeName
             - name: INFRACLUSTER_NAMESPACE
               valueFrom:
-                secretKeyRef:
-                  name: infra-cluster-credentials
-                  key: namespace
-            - name: INFRACLUSTER_API_URL
-              valueFrom:
-                secretKeyRef:
-                  name: infra-cluster-credentials
-                  key: apiUrl
+                configMapKeyRef:
+                  name: driver-config
+                  key: infraClusterNamespace
           volumeMounts:
             - name: infracluster
               mountPath: "/var/run/secrets/infracluster"

--- a/deploy/040-controller.yaml
+++ b/deploy/040-controller.yaml
@@ -32,9 +32,7 @@ spec:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--namespace=kubevirt-csi-driver"
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"
-            - "--infra-cluster-api-url=$(INFRACLUSTER_API_URL)"
-            - "--infra-cluster-token=/var/run/secrets/infracluster/token"
-            - "--infra-cluster-ca=/var/run/secrets/infracluster/service-ca.crt"
+            - "--infra-cluster-kubeconfig=/var/run/secrets/infracluster/kubeconfig"
             - --v=5
           ports:
             - name: healthz
@@ -50,14 +48,9 @@ spec:
                   fieldPath: spec.nodeName
             - name: INFRACLUSTER_NAMESPACE
               valueFrom:
-                secretKeyRef:
-                  name: infra-cluster-credentials
-                  key: namespace
-            - name: INFRACLUSTER_API_URL
-              valueFrom:
-                secretKeyRef:
-                  name: infra-cluster-credentials
-                  key: apiUrl
+                configMapKeyRef:
+                  name: driver-config
+                  key: infraClusterNamespace
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
-  name: infra-cluster-credentials
+  name: driver-config
   namespace: kubevirt-csi-driver
 data:
-  kubeconfig: 
+  infraClusterNamespace: 

--- a/deploy/example/infracluster-kubeconfig.yaml
+++ b/deploy/example/infracluster-kubeconfig.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: <Base64 of CA. Take value from the kubeconfig used to create the ServiceAccount kubevirt-csi>
+    server: <URL of cluster. E.g.https://api.crc.testing:6443. Take value from the kubeconfig used to create the ServiceAccount kubevirt-csi>
+  name: infra-cluster
+contexts:
+- context:
+    cluster: infra-cluster
+    namespace: <optional, not used>
+    user: kubevirt-csi
+  name: only-context
+current-context: only-context
+kind: Config
+preferences: {}
+users:
+- name: kubevirt-csi
+  user:
+    token: <use token from secret in ServiceAccount kubevirt-csi. Decode it from base64 (base64 -d)>


### PR DESCRIPTION
Use kubeconfig instead of token and add ConfigMap.
Use kubeconfig in secret instead of multiple authentication fields.
New ConfigMap holds the infra/platform cluster namespace.