### PR TITLE
OCPCNV-176 installer unique label

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This repository hosts the CSI KubeVirt driver and all of its build and dependent
 - use `deploy/secret.yaml` for creating the necessary secret in the tenant cluster
     - set kubeconfig: [base64 of kubeconfig from previous step]
 - use `deploy/configmap.yaml` for creating the driver's config
-    - set infraClusterNamespace to the kubevirt cluster namepsace.
+    - set infraClusterNamespace to the kubevirt cluster namespace.
+    - set infraClusterLabels. The format is 'key=value,key=value,...'. The driver creates resources in the infra cluster. These resources are labeled with the values you supply in infraClusterLabels. Provide values that make the labels unique to your cluster. One usage of such labels is for destroying the tenant cluster. The labels tells us what resources were created in the infra cluster for serving the tenant.
 - deploy files under `deploy` in  tenant cluster
     - 000-csi-driver.yaml
     - 020-authorization.yaml

--- a/deploy/030-node.yaml
+++ b/deploy/030-node.yaml
@@ -43,6 +43,11 @@ spec:
                 configMapKeyRef:
                   name: driver-config
                   key: infraClusterNamespace
+            - name: INFRACLUSTER_LABELS
+              valueFrom:
+                configMapKeyRef:
+                  name: driver-config
+                  key: infraClusterLabels
           volumeMounts:
             - name: infracluster
               mountPath: "/var/run/secrets/infracluster"

--- a/deploy/040-controller.yaml
+++ b/deploy/040-controller.yaml
@@ -33,6 +33,7 @@ spec:
             - "--namespace=kubevirt-csi-driver"
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"
             - "--infra-cluster-kubeconfig=/var/run/secrets/infracluster/kubeconfig"
+            - "--infra-cluster-labels=$(INFRACLUSTER_LABELS)"
             - --v=5
           ports:
             - name: healthz
@@ -51,6 +52,11 @@ spec:
                 configMapKeyRef:
                   name: driver-config
                   key: infraClusterNamespace
+            - name: INFRACLUSTER_LABELS
+              valueFrom:
+                configMapKeyRef:
+                  name: driver-config
+                  key: infraClusterLabels
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: kubevirt-csi-driver
 data:
   infraClusterNamespace: 
+  infraClusterLabels: key=value,key=value,...

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -27,10 +27,11 @@ const (
 	hotplugDiskPrefix              = "disk-"
 )
 
-//ControllerService implements the controller interface
+//ControllerService implements the controller interface. See README for details.
 type ControllerService struct {
 	infraClient           client.Client
 	infraClusterNamespace string
+	infraClusterLabels    map[string]string
 }
 
 var controllerCaps = []csi.ControllerServiceCapability_RPC_Type{
@@ -60,6 +61,7 @@ func (c *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	dv.Namespace = c.infraClusterNamespace
 	dv.Kind = "DataVolume"
 	dv.APIVersion = cdiv1.SchemeGroupVersion.String()
+	dv.ObjectMeta.Labels = c.infraClusterLabels
 	dv.Spec.PVC = &corev1.PersistentVolumeClaimSpec{
 		AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		StorageClassName: &storageClassName,

--- a/pkg/service/driver.go
+++ b/pkg/service/driver.go
@@ -23,14 +23,15 @@ type KubevirtCSIDriver struct {
 	Client             kubevirt.Client
 }
 
-func NewKubevirtCSIDriver(infraClusterClient kubevirt.Client, infraClusterNamespace string, nodeID string) *KubevirtCSIDriver {
+func NewKubevirtCSIDriver(infraClusterClient kubevirt.Client, infraClusterNamespace string, infraClusterLabels map[string]string, nodeID string) *KubevirtCSIDriver {
 	d := KubevirtCSIDriver{
 		IdentityService: &IdentityService{
 			infraClusterClient: infraClusterClient,
 		},
 		ControllerService: &ControllerService{
-			infraClusterNamespace: infraClusterNamespace,
 			infraClient:           infraClusterClient,
+			infraClusterNamespace: infraClusterNamespace,
+			infraClusterLabels:    infraClusterLabels,
 		},
 		NodeService: NewNodeService(infraClusterClient, nodeID),
 	}


### PR DESCRIPTION
[OCPCNV-176](https://issues.redhat.com/browse/OCPCNV-176) Resources created in infracluster should include "installer unique label"
In case tenant cluster which has PVCs created by CSI driver is destroyed by the installer, also the DVs related to those PVCs should be removed.