### PR TITLE
autodetect kubevirtci cri runtime and update k8s provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,8 @@ TARGET_NAME=kubevirt-csi-driver
 IMAGE_REF=quay.io/kubevirt/$(TARGET_NAME):latest
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 IMAGE_REGISTRY?=registry.svc.ci.openshift.org
-KUBEVIRTCI_RUNTIME?=podman
-KUBEVIRT_PROVIDER?=k8s-1.21
+KUBEVIRT_PROVIDER?=k8s-1.23
 
-export KUBEVIRTCI_RUNTIME
 export KUBEVIRT_PROVIDER
 
 # You can customize go tools depending on the directory layout.

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -21,7 +21,6 @@ set -e
 
 ## source cluster/kubevirtci.sh
 
-KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.17}
 BASE_PATH=${KUBEVIRTCI_CONFIG_PATH:-$PWD}
 ## KUBEVIRTCI_PATH=$(kubevirtci::path)
 CMD=${CMD:-}


### PR DESCRIPTION
I don't think we should explicitly set the KUBEVIRTCI_RUNTIME. I believe kubevirtci will detect whether podman or docker is in use and default correctly. 

Also, we should update to the most recent k8s provider by default while we're revitalization the project.


```release-note
NONE
```

