### PR TITLE
Change the image building to the standard way

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+cluster-up/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,17 @@ COPY . .
 RUN make build
 
 FROM quay.io/centos/centos:stream9
-LABEL maintainers="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
-LABEL description="KubeVirt CSI Driver"
+ARG git_url=https://github.com/kubevirt/cdi-driver.git
 
-RUN dnf install -y e2fsprogs xfsprogs && dnf clean all
-COPY --from=builder /src/kubevirt-csi-driver/kubevirt-csi-driver .
+LABEL maintainers="The KubeVirt Project <kubevirt-dev@googlegroups.com>" \
+      description="KubeVirt CSI Driver" \
+      multi.GIT_URL=${git_url}
 
 ENTRYPOINT ["./kubevirt-csi-driver"]
+
+RUN dnf install -y e2fsprogs xfsprogs && dnf clean all
+
+ARG git_sha=NONE
+LABEL multi.GIT_SHA=${git_sha}
+
+COPY --from=builder /src/kubevirt-csi-driver/kubevirt-csi-driver .

--- a/hack/cri-bin.sh
+++ b/hack/cri-bin.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if podman ps >/dev/null; then
+    _cri_bin=podman
+    >&2 echo "selecting podman as container runtime"
+elif docker ps >/dev/null; then
+    _cri_bin=docker
+    >&2 echo "selecting docker as container runtime"
+else
+    >&2 echo "no working container runtime found. Neither docker nor podman seems to work."
+    exit 1
+fi
+
+CRI_BIN=${_cri_bin}


### PR DESCRIPTION
Modified the Makefile to use docker/podman instead of the imagebuilder
macro.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

