### PR TITLE
Add ability to split Controller to infra cluster and Node to tenant cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
+ARG builder_image=docker.io/library/golang:1.18.2
+FROM ${builder_image} AS builder
 WORKDIR /src/kubevirt-csi-driver
 COPY . .
 RUN make build

--- a/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+++ b/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
@@ -23,8 +23,10 @@ var (
 	endpoint               = flag.String("endpoint", "unix:/csi/csi.sock", "CSI endpoint")
 	nodeName               = flag.String("node-name", "", "The node name - the node this pods runs on")
 	infraClusterNamespace  = flag.String("infra-cluster-namespace", "", "The infra-cluster namespace")
-	infraClusterKubeconfig = flag.String("infra-cluster-kubeconfig", "", "the infra-cluster kubeconfig file")
+	infraClusterKubeconfig = flag.String("infra-cluster-kubeconfig", "", "the infra-cluster kubeconfig file. If not set, defaults to in cluster config.")
 	infraClusterLabels     = flag.String("infra-cluster-labels", "", "The infra-cluster labels to use when creating resources in infra cluster. 'name=value' fields separated by a comma")
+
+	tenantClusterKubeconfig = flag.String("tenant-cluster-kubeconfig", "", "the tenant cluster kubeconfig file. If not set, defaults to in cluster config.")
 )
 
 func init() {
@@ -57,27 +59,49 @@ func main() {
 }
 
 func handle() {
+	var tenantRestConfig *rest.Config
+	var infraRestConfig *rest.Config
+
 	if service.VendorVersion == "" {
 		klog.Fatalf("VendorVersion must be set at compile time")
 	}
 	klog.V(2).Infof("Driver vendor %v %v", service.VendorName, service.VendorVersion)
 
-	tenantConfig, err := rest.InClusterConfig()
+	inClusterConfig, err := rest.InClusterConfig()
 	if err != nil {
-		klog.Fatalf("Failed to build tenant cluster config: %v", err)
+		klog.Fatalf("Failed to build in cluster config: %v", err)
 	}
 
-	tenantClientSet, err := kubernetes.NewForConfig(tenantConfig)
+	if *tenantClusterKubeconfig == "" && *infraClusterKubeconfig == "" {
+		klog.Fatalf("either infra-cluster-kubeconfig or tenant-cluster-kubeconfig must be defined")
+	}
+
+	if *tenantClusterKubeconfig != "" {
+		tenantRestConfig, err = clientcmd.BuildConfigFromFlags("", *tenantClusterKubeconfig)
+		if err != nil {
+			klog.Fatalf("failed to build tenant cluster config: %v", err)
+		}
+
+	} else {
+		tenantRestConfig = inClusterConfig
+	}
+
+	if *infraClusterKubeconfig != "" {
+		infraRestConfig, err = clientcmd.BuildConfigFromFlags("", *infraClusterKubeconfig)
+		if err != nil {
+			klog.Fatalf("failed to build infra cluster config: %v", err)
+		}
+
+	} else {
+		infraRestConfig = inClusterConfig
+	}
+
+	tenantClientSet, err := kubernetes.NewForConfig(tenantRestConfig)
 	if err != nil {
 		klog.Fatalf("Failed to build tenant client set: %v", err)
 	}
 
-	infraClusterConfig, err := clientcmd.BuildConfigFromFlags("", *infraClusterKubeconfig)
-	if err != nil {
-		klog.Fatalf("Failed to build infra cluster config: %v", err)
-	}
-
-	virtClient, err := kubevirt.NewClient(infraClusterConfig)
+	virtClient, err := kubevirt.NewClient(infraRestConfig)
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+++ b/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
@@ -42,7 +42,7 @@ func init() {
 	klog.InitFlags(klogFlags)
 
 	// Sync the glog and klog flags.
-	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
+	flag.CommandLine.Visit(func(f1 *flag.Flag) {
 		f2 := klogFlags.Lookup(f1.Name)
 		if f2 != nil {
 			value := f1.Value.String()

--- a/deploy/030-node.yaml
+++ b/deploy/030-node.yaml
@@ -29,7 +29,6 @@ spec:
           image: quay.io/kubevirt/csi-driver:latest
           args:
             - "--endpoint=unix:/csi/csi.sock"
-            - "--namespace=kubevirt-csi-driver"
             - "--node-name=$(KUBE_NODE_NAME)"
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"
             - "--infra-cluster-kubeconfig=/var/run/secrets/infracluster/kubeconfig"

--- a/deploy/040-controller.yaml
+++ b/deploy/040-controller.yaml
@@ -30,7 +30,6 @@ spec:
           image: quay.io/kubevirt/csi-driver:latest
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
-            - "--namespace=kubevirt-csi-driver"
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"
             - "--infra-cluster-kubeconfig=/var/run/secrets/infracluster/kubeconfig"
             - "--infra-cluster-labels=$(INFRACLUSTER_LABELS)"

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -28,7 +28,7 @@ const (
 
 //ControllerService implements the controller interface. See README for details.
 type ControllerService struct {
-	infraClient           client.Client
+	virtClient            client.Client
 	infraClusterNamespace string
 	infraClusterLabels    map[string]string
 }
@@ -77,7 +77,7 @@ func (c *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	dv.Spec.Source.Blank = &cdiv1.DataVolumeBlankImage{}
 
 	// Create DataVolume
-	dv, err := c.infraClient.CreateDataVolume(c.infraClusterNamespace, dv)
+	dv, err := c.virtClient.CreateDataVolume(c.infraClusterNamespace, dv)
 
 	if err != nil {
 		log.Error("Failed creating DataVolume " + dvName)
@@ -105,7 +105,7 @@ func (c *ControllerService) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	dvName := req.VolumeId
 	log.Infof("Removing data volume with %s", dvName)
 
-	err := c.infraClient.DeleteDataVolume(c.infraClusterNamespace, dvName)
+	err := c.virtClient.DeleteDataVolume(c.infraClusterNamespace, dvName)
 	if err != nil {
 		log.Error("Failed deleting DataVolume " + dvName)
 		return nil, err
@@ -155,7 +155,7 @@ func (c *ControllerService) ControllerPublishVolume(
 		},
 	}
 
-	err = c.infraClient.AddVolumeToVM(c.infraClusterNamespace, vmName, addVolumeOptions)
+	err = c.virtClient.AddVolumeToVM(c.infraClusterNamespace, vmName, addVolumeOptions)
 	if err != nil {
 		log.Error("Failed adding volume " + dvName + " to VM " + vmName)
 		return nil, err
@@ -176,7 +176,7 @@ func (c *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 	}
 
 	// Detach DataVolume from VM
-	err = c.infraClient.RemoveVolumeFromVM(c.infraClusterNamespace, vmName, &kubevirtv1.RemoveVolumeOptions{Name: dvName})
+	err = c.virtClient.RemoveVolumeFromVM(c.infraClusterNamespace, vmName, &kubevirtv1.RemoveVolumeOptions{Name: dvName})
 	if err != nil {
 		log.Error("Failed removing volume " + dvName + " from VM " + vmName)
 		return nil, err
@@ -246,7 +246,7 @@ func (c *ControllerService) ControllerGetVolume(_ context.Context, _ *csi.Contro
 // getVMNameByCSINodeID finds a VM in infra cluster by its firmware uuid. The uid is the ID that the CSI
 // node publishes in NodeGetInfo and then used by CSINode.spec.drivers[].nodeID
 func (c *ControllerService) getVMNameByCSINodeID(nodeID string) (string, error) {
-	list, err := c.infraClient.ListVirtualMachines(c.infraClusterNamespace)
+	list, err := c.virtClient.ListVirtualMachines(c.infraClusterNamespace)
 	if err != nil {
 		log.Error("Failed listing VMIs in infra cluster")
 		return "", err

--- a/pkg/service/driver.go
+++ b/pkg/service/driver.go
@@ -31,7 +31,7 @@ func NewKubevirtCSIDriver(infraClusterClient kubevirt.Client, infraClusterNamesp
 			infraClusterNamespace: infraClusterNamespace,
 			infraClusterLabels:    infraClusterLabels,
 		},
-		NodeService: NewNodeService(infraClusterClient, nodeID),
+		NodeService: NewNodeService(nodeID),
 	}
 	return &d
 }

--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -15,8 +15,6 @@ import (
 
 	"golang.org/x/net/context"
 	klog "k8s.io/klog/v2"
-
-	"kubevirt.io/csi-driver/pkg/kubevirt"
 )
 
 var nodeCaps = []csi.NodeServiceCapability_RPC_Type{
@@ -40,7 +38,7 @@ type dirMaker interface {
 	Make(path string, perm os.FileMode) error
 }
 
-func NewNodeService(infraClusterClient kubevirt.Client, nodeId string) *NodeService {
+func NewNodeService(nodeId string) *NodeService {
 	return &NodeService{
 		nodeID: nodeId,
 		deviceLister: deviceListerFunc(func() ([]byte, error) {


### PR DESCRIPTION
This adds the ability to run the csi controller on the infra node while and the csi node daemonset on the tenant cluster independently of one another. With this split, it is possible to remove all infra cluster access from the tenant cluster.

Signed-off-by: David Vossel <davidvossel@gmail.com>
Co-authored-by: isaacdorfman <isaac.i.dorfman@gmail.com>

```release-note
Add ability to split Controller to infra cluster and Node to tenant cluster
```