### PR TITLE
Uses a builder container that exists in openshift builder dockerfile

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 WORKDIR /src/kubevirt-csi-driver
 COPY . .
 RUN make build


### PR DESCRIPTION

`registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.11` apparently doesn't exist. I replaced it with an image that works.

```release-note
NONE
```

