### PR TITLE
Linter: bigger timeout

### DIFF
--- a/hack/run-linter.sh
+++ b/hack/run-linter.sh
@@ -6,7 +6,7 @@ if [ ! -f "$(go env GOPATH)/bin/golangci-lint" ]; then
   curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin"
 fi
 
-golangci-lint run --timeout=5m
+golangci-lint run --verbose --timeout=10m
 
 if [ ! -f "$(go env GOPATH)/bin/ginkgolinter" ]; then
   # install ginkgolinter


### PR DESCRIPTION

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Linter fails often: 
https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-csi-driver-linter
```
level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
make: *** [Makefile:105: linter] Error 4
```
https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_csi-driver/39/pull-csi-driver-linter/1561765989392060416/build-log.txt

This PR configures bigger timeout

Also enabled verbose logging to see what is actually going on
when the linter timeouts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

