### PR TITLE
[Clean-code]: Equal(true) => BeTrue()

### DIFF
--- a/pkg/service/service_suite_test.go
+++ b/pkg/service/service_suite_test.go
@@ -236,7 +236,7 @@ var _ = Describe("IdentityService", func() {
 			})
 
 			It("should return a Ready response", func() {
-				Expect(res.GetReady().Value).Should(Equal(true))
+				Expect(res.GetReady().Value).Should(BeTrue())
 			})
 
 		})


### PR DESCRIPTION
Use a dedicated gomega matcher instead of a general purpose matcher.

Replace gomega `Equal(true)` with `BeTrue()`

This will also be required by the ginkgo linter next release.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

