### PR TITLE
Added an allow list for infra-stroage-class to volumes

### DIFF
--- a/deploy/040-controller.yaml
+++ b/deploy/040-controller.yaml
@@ -54,6 +54,12 @@ spec:
                 configMapKeyRef:
                   name: driver-config
                   key: infraClusterLabels
+            - name: INFRA_STORAGE_CLASS_ENFORCEMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: driver-config
+                  key: infraStorageClassEnforcement
+                  optional: true
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/deploy/split-infra-tenant/040-controller.yaml
+++ b/deploy/split-infra-tenant/040-controller.yaml
@@ -55,6 +55,12 @@ spec:
                 configMapKeyRef:
                   name: driver-config
                   key: infraClusterLabels
+            - name: INFRA_STORAGE_CLASS_ENFORCEMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: driver-config
+                  key: infraStorageClassEnforcement
+                  optional: true
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b
 	google.golang.org/grpc v1.48.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v12.0.0+incompatible
@@ -72,7 +73,6 @@ require (
 	google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect

--- a/pkg/service/driver.go
+++ b/pkg/service/driver.go
@@ -5,6 +5,7 @@ import (
 	klog "k8s.io/klog/v2"
 
 	"kubevirt.io/csi-driver/pkg/kubevirt"
+	"kubevirt.io/csi-driver/pkg/util"
 )
 
 var (
@@ -26,6 +27,7 @@ func NewKubevirtCSIDriver(virtClient kubevirt.Client,
 	identityClientset kubernetes.Interface,
 	infraClusterNamespace string,
 	infraClusterLabels map[string]string,
+	storageClassEnforcement util.StorageClassEnforcement,
 	nodeID string,
 	runNodeService bool,
 	runControllerService bool) *KubevirtCSIDriver {
@@ -35,9 +37,10 @@ func NewKubevirtCSIDriver(virtClient kubevirt.Client,
 
 	if runControllerService {
 		d.ControllerService = &ControllerService{
-			virtClient:            virtClient,
-			infraClusterNamespace: infraClusterNamespace,
-			infraClusterLabels:    infraClusterLabels,
+			virtClient:             virtClient,
+			infraClusterNamespace:  infraClusterNamespace,
+			infraClusterLabels:     infraClusterLabels,
+			storageClassEnforcement: storageClassEnforcement,
 		}
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,7 @@
+package util
+
+type StorageClassEnforcement struct {
+	AllowList []string `yaml:"allowList"`
+	AllowAll bool `yaml:"allowAll"`
+	AllowDefault bool `yaml:"allowDefault"`
+}

--- a/sanity/sanity_suite_test.go
+++ b/sanity/sanity_suite_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/mount"
 	"kubevirt.io/csi-driver/pkg/service"
+	"kubevirt.io/csi-driver/pkg/util"
 )
 
 var (
@@ -40,10 +41,17 @@ var _ = ginkgo.BeforeSuite(func() {
 	service.NewFsMaker = func() service.FsMaker {
 		return &fakeFsMaker{}
 	}
+
+	storagClassEnforcement := util.StorageClassEnforcement{
+		AllowAll:     true,
+		AllowDefault: true,
+	}
+
 	driver := service.NewKubevirtCSIDriver(virtClient,
 		identityClientset,
 		infraClusterNamespace,
 		infraClusterLabelsMap,
+		storagClassEnforcement,
 		nodeID,
 		true,
 		true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds a "allowedInfraStorageclasses" field to the csi driver configmap.
This field prevents users for using an arbitrary infra storage class from within the tenant cluster and allows the manager of the infra cluster to specify which storage classes tenants are allowed to use.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
https://github.com/kubevirt/csi-driver/issues/59
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds infra storage class enforcement policy
```

