### PR TITLE
Remove unused CRD list/create rbac 

### DIFF
--- a/deploy/020-autorization.yaml
+++ b/deploy/020-autorization.yaml
@@ -15,10 +15,6 @@ kind: ClusterRole
 metadata:
   name: kubevirt-csi-controller-cr
 rules:
-  # Allow listing and creating CRDs
-  - apiGroups: ['apiextensions.k8s.io']
-    resources: ['customresourcedefinitions']
-    verbs: ['list', 'create']
   - apiGroups: ['']
     resources: ['persistentvolumes']
     verbs: ['create', 'delete', 'get', 'list', 'watch', 'update', 'patch']

--- a/deploy/split-infra-tenant/020-controller-authorization.yaml
+++ b/deploy/split-infra-tenant/020-controller-authorization.yaml
@@ -9,10 +9,6 @@ kind: ClusterRole
 metadata:
   name: kubevirt-csi-controller-cr
 rules:
-  # Allow listing and creating CRDs
-  - apiGroups: ['apiextensions.k8s.io']
-    resources: ['customresourcedefinitions']
-    verbs: ['list', 'create']
   - apiGroups: ['']
     resources: ['persistentvolumes']
     verbs: ['create', 'delete', 'get', 'list', 'watch', 'update', 'patch']


### PR DESCRIPTION
Maybe we needed the ability to list/create CRDs in the past, but that is no longer necessary for the existing csi driver.


```release-note
NONE
```

