### PR TITLE
Mark DVs to be retained by cdi

### DIFF
--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -89,6 +89,9 @@ func (c *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 	dv.Kind = "DataVolume"
 	dv.APIVersion = cdiv1.SchemeGroupVersion.String()
 	dv.ObjectMeta.Labels = c.infraClusterLabels
+	dv.ObjectMeta.Annotations = map[string]string{
+		"cdi.kubevirt.io/storage.deleteAfterCompletion": "false",
+	}
 	dv.Spec.PVC = &corev1.PersistentVolumeClaimSpec{
 		AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		StorageClassName: &storageClassName,


### PR DESCRIPTION
Fixes: #68 

CDI recently made a change to enable automatically garbage collecting datavolumes after import [1].

For our csi controller to continue operating as expected, we need to mark our DVs to be retained. In the future we may consider allowing the garbage collection to occur, and read the PVC to see if the import already succeeded. But for now, it's nice to continue with the existing way this operates because it doesn't involve changing any rbac or tracking multiple objects (dv + pvc)

1. https://github.com/kubevirt/containerized-data-importer/pull/2421 


```release-note
NONE
```

