### PR TITLE
Use default infra storage class when no infra storage class is defined

### DIFF
--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -93,14 +93,21 @@ func (c *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		"cdi.kubevirt.io/storage.deleteAfterCompletion": "false",
 	}
 	dv.Spec.PVC = &corev1.PersistentVolumeClaimSpec{
-		AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-		StorageClassName: &storageClassName,
-		VolumeMode:       &volumeMode,
+		AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		VolumeMode:  &volumeMode,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceStorage: *resource.NewScaledQuantity(storageSize, 0)},
 		},
 	}
+
+	// Only set the storageclass if it is defined. Otherwise we use the
+	// default storage class which means leaving the storageclass empty
+	// (nil) on the PVC
+	if storageClassName != "" {
+		dv.Spec.PVC.StorageClassName = &storageClassName
+	}
+
 	dv.Spec.Source = &cdiv1.DataVolumeSource{}
 	dv.Spec.Source.Blank = &cdiv1.DataVolumeBlankImage{}
 


### PR DESCRIPTION
If there's no infra storage class defined in the guest storage class, use the default one. This gives us a default option where we can create a standard StorageClass object in the guest that will work across all infra as long as the infra defines a default itself.

This behavior is enforced on the infra side by the work @isaacdorfman perfomed in https://github.com/kubevirt/csi-driver/pull/62

```release-note
NONE
```

