### PR TITLE
Add release github action

### DIFF
--- a/.github/workflows/create_image.yaml
+++ b/.github/workflows/create_image.yaml
@@ -1,0 +1,25 @@
+on:
+  pull_request:
+    branches:
+    - main
+    types: [closed]
+name: Create and push image
+
+jobs:
+  build-and-push-image:
+    if: ${{ github.event.pull_request.merged && (github.repository == 'kubevirt/csi-driver'}})
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: build image
+      shell: bash
+      env:
+        QUAY_PWD: ${{secrets.QUAY_TOKEN}}
+        REGISTRY: "quay.io/kubevirt"
+        TARGET_NAME: "kubevirt-csi-driver"
+        TAG: "latest"
+      run: |
+        echo "${QUAY_PWD}" | docker login -u="kubevirt+csidriver" quay.io --password-stdin
+        make image-build
+        make image-push

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,0 +1,27 @@
+on:
+  push:
+    tags:
+    - "v*"
+  release:
+    types: [published]
+
+name: Create and push released image
+
+jobs:
+  build-and-push-image:
+    if: (github.repository == 'kubevirt/csi-driver')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: build image
+      shell: bash
+      env:
+        QUAY_TOKEN: ${{secrets.QUAY_TOKEN}}
+        REGISTRY: "quay.io/kubevirt"
+        TARGET_NAME: "kubevirt-csi-driver"
+        TAG: ${{ github.ref_name }}
+      run: |
+        echo $QUAY_TOKEN | docker login -u="kubevirt+csidriver" quay.io --password-stdin
+        make image-build
+        make image-push


### PR DESCRIPTION
Add a new github action to build and push the kubevirt-csi-driver image, with the release tag.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

