### PR TITLE
Use the CDI storage api

### DIFF
--- a/hack/cluster-sync-split.sh
+++ b/hack/cluster-sync-split.sh
@@ -81,6 +81,7 @@ cluster::generate_driver_configmap_overlay "controller-infra"
 cluster::generate_infra_controller_overlay
 cluster::generate_node_overlay
 cluster::generate_storageclass_overlay "tenant" $INFRA_STORAGE_CLASS
+cluster::patch_local_storage_profile
 
 # ******************************************************
 # Deploy the tenant yaml

--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -104,6 +104,7 @@ cluster::generate_driver_configmap_overlay "tenant"
 cluster::generate_tenant_controller_overlay
 cluster::generate_node_overlay
 cluster::generate_storageclass_overlay "tenant" $INFRA_STORAGE_CLASS
+cluster::patch_local_storage_profile
 
 # ******************************************************
 # Deploy the tenant yaml

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -118,3 +118,9 @@ metadata:
     name: $1
 END
 }
+
+function cluster::patch_local_storage_profile() {
+if ./kubevirtci kubectl get storageprofile local; then
+  ./kubevirtci kubectl patch storageprofile local --type='merge' -p '{"spec":{"claimPropertySets":[{"accessModes":["ReadWriteOnce"], "volumeMode": "Filesystem"}]}}'
+fi
+}

--- a/hack/run-k8s-e2e.sh
+++ b/hack/run-k8s-e2e.sh
@@ -120,11 +120,18 @@ spec:
 EOF
 }
 
+function patch_local_storage_profile() {
+if ./kubevirtci kubectl get storageprofile local; then
+  ./kubevirtci kubectl patch storageprofile local --type='merge' -p '{"spec":{"claimPropertySets":[{"accessModes":["ReadWriteOnce"], "volumeMode": "Filesystem"}]}}'
+fi
+}
+
 trap cleanup EXIT SIGSTOP SIGKILL SIGTERM
 ensure_cluster_up
 ensure_synced
 create_test_driver_cm
 create_capk_secret
+patch_local_storage_profile
 start_test_pod
 # Wait for pod to be ready before getting logs
 ./kubevirtci kubectl wait pods -n $TENANT_CLUSTER_NAMESPACE ${test_pod} --for condition=Ready --timeout=180s

--- a/pkg/service/controller_test.go
+++ b/pkg/service/controller_test.go
@@ -22,7 +22,7 @@ func TestCreateVolumeDefaultStorageClass_Success(t *testing.T) {
 	origStorageClass := testInfraStorageClassName
 	testInfraStorageClassName = ""
 	storageClassEnforcement = util.StorageClassEnforcement{
-		AllowAll: true,
+		AllowAll:     true,
 		AllowDefault: true,
 	}
 	defer func() { testInfraStorageClassName = origStorageClass }()
@@ -78,8 +78,8 @@ func TestCreateVolume_NotAllowedStorageClass(t *testing.T) {
 	allowedStorageClasses = []string{"allowedClass"}
 	allowAllStorageClasses = false
 	storageClassEnforcement = util.StorageClassEnforcement{
-		AllowList: []string{"allowedClass"},
-		AllowAll: false,
+		AllowList:    []string{"allowedClass"},
+		AllowAll:     false,
 		AllowDefault: true,
 	}
 	controller := ControllerService{client, testInfraNamespace, testInfraLabels, storageClassEnforcement}
@@ -141,8 +141,8 @@ var (
 	testInfraLabels                               = map[string]string{"infra-label-name": "infra-label-value"}
 	allowedStorageClasses                         = []string{}
 	allowAllStorageClasses                        = true
-	storageClassEnforcement = util.StorageClassEnforcement{
-		AllowAll: true,
+	storageClassEnforcement                       = util.StorageClassEnforcement{
+		AllowAll:     true,
 		AllowDefault: true,
 	}
 )
@@ -272,14 +272,13 @@ func (c *ControllerClientMock) CreateDataVolume(namespace string, dataVolume *cd
 	// Test input
 	assert.Equal(c.t, testVolumeName, dataVolume.GetName())
 	if testInfraStorageClassName != "" {
-		assert.Equal(c.t, testInfraStorageClassName, *dataVolume.Spec.PVC.StorageClassName)
+		assert.Equal(c.t, testInfraStorageClassName, *dataVolume.Spec.Storage.StorageClassName)
 	} else {
-		assert.Nil(c.t, dataVolume.Spec.PVC.StorageClassName)
+		assert.Nil(c.t, dataVolume.Spec.Storage.StorageClassName)
 	}
-	q, ok := dataVolume.Spec.PVC.Resources.Requests[corev1.ResourceStorage]
+	q, ok := dataVolume.Spec.Storage.Resources.Requests[corev1.ResourceStorage]
 	assert.True(c.t, ok)
 	assert.Equal(c.t, 0, q.CmpInt64(testVolumeStorageSize))
-	assert.Equal(c.t, testVolumeMode, *dataVolume.Spec.PVC.VolumeMode)
 	assert.Equal(c.t, testInfraLabels, dataVolume.Labels)
 
 	// Input OK. Now prepare result


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This way we pick optimal PVC settings for the infra cluster storage class. For instance if using ceph in the infra cluster it makes sense to use block volumes instead of filesystem. And it makes sense to use RWX in that case as well. The storage API determines these optimal values based on the storage class.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use CDI storage api to pick optimal PVC settings for infra storage class
```

