### PR TITLE
Update kubevirt CI to latest, and kubevirt to 0.58.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ TAG ?= latest
 IMAGE_REF=$(REGISTRY)/$(TARGET_NAME):$(TAG)
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 IMAGE_REGISTRY?=registry.svc.ci.openshift.org
-KUBEVIRT_PROVIDER?=k8s-1.23
+KUBEVIRT_PROVIDER?=k8s-1.25
 SHA := $(shell git describe --no-match  --always --abbrev=40 --dirty)
 BIN_DIR := bin
 

--- a/deploy/controller-infra/base/deploy.yaml
+++ b/deploy/controller-infra/base/deploy.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccount: kubevirt-csi
       priorityClassName: system-cluster-critical
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists

--- a/hack/ci/e2e-latest-split.sh
+++ b/hack/ci/e2e-latest-split.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-export KUBEVIRT_PROVIDER=k8s-1.23
+export KUBEVIRT_PROVIDER=k8s-1.25
 
 make cluster-up
 make cluster-sync-split

--- a/hack/ci/e2e-latest.sh
+++ b/hack/ci/e2e-latest.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-export KUBEVIRT_PROVIDER=k8s-1.23
+export KUBEVIRT_PROVIDER=k8s-1.25
 
 make cluster-up
 make cluster-sync

--- a/hack/cluster-sync-split.sh
+++ b/hack/cluster-sync-split.sh
@@ -95,5 +95,5 @@ _kubectl apply --kustomize ./deploy/controller-infra/dev-overlay
 # ******************************************************
 # Wait for driver to rollout
 # ******************************************************
-_kubectl_tenant rollout status ds/kubevirt-csi-node -n $CSI_DRIVER_NAMESPACE --timeout=5m
-_kubectl rollout status deployment/kubevirt-csi-controller -n $TENANT_CLUSTER_NAMESPACE --timeout=5m
+_kubectl_tenant rollout status ds/kubevirt-csi-node -n $CSI_DRIVER_NAMESPACE --timeout=10m
+_kubectl rollout status deployment/kubevirt-csi-controller -n $TENANT_CLUSTER_NAMESPACE --timeout=10m

--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -10,9 +10,7 @@ TARGET_NAME=${TARGET_NAME:-kubevirt-csi-driver}
 TAG=${TAG:-latest}
 
 function tenant::deploy_kubeconfig_secret() {
-  TOKEN_NAME=$(_kubectl -n $TENANT_CLUSTER_NAMESPACE get serviceaccount/kubevirt-csi -o jsonpath='{.secrets[0].name}')
-  CA_CRT=$(_kubectl -n $TENANT_CLUSTER_NAMESPACE get secret $TOKEN_NAME -o json | jq '.data["ca.crt"]' | xargs echo)
-  TOKEN=$(_kubectl -n $TENANT_CLUSTER_NAMESPACE get secret $TOKEN_NAME -o json | jq '.data["token"]' | xargs echo | base64 -d)
+  TOKEN=$(_kubectl create token kubevirt-csi -n $TENANT_CLUSTER_NAMESPACE)
   INTERNAL_IP=$(_kubectl get node -l "node-role.kubernetes.io/control-plane" -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
 
   kubeconfig=$(cat <<- END

--- a/hack/run-k8s-e2e.sh
+++ b/hack/run-k8s-e2e.sh
@@ -13,11 +13,10 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 set -e
-export KUBEVIRT_PROVIDER=k8s-1.23
 export TENANT_CLUSTER_NAME=${TENANT_CLUSTER_NAME:-kvcluster}
 export TENANT_CLUSTER_NAMESPACE=${TENANT_CLUSTER_NAMESPACE:-kvcluster}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2205231118-f12b50e}
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.23}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2301240001-e641e98}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.25}
 
 test_pod=${TENANT_CLUSTER_NAME}-k8s-e2e-suite-runnner
 test_driver_cm=${TENANT_CLUSTER_NAME}-test-driver

--- a/kubevirtci
+++ b/kubevirtci
@@ -2,9 +2,9 @@
 
 set -e
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.23}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.25}
 export CAPK_GUEST_K8S_VERSION=${CAPK_GUEST_K8S_VERSION:-v1.22.0}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2205231118-f12b50e}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2301240001-e641e98}
 export KUBECONFIG=$(cluster-up/cluster-up/kubeconfig.sh)
 export KUBEVIRT_DEPLOY_PROMETHEUS=false
 export KUBEVIRT_DEPLOY_CDI=false
@@ -15,7 +15,7 @@ export METALLB_VERSION="v0.12.1"
 export CAPK_RELEASE_VERSION="v0.1.0-rc.0"
 export CLUSTERCTL_VERSION="v1.0.0"
 export CALICO_VERSION="v3.21"
-export KUBEVIRT_VERSION="v0.53.0"
+export KUBEVIRT_VERSION="v0.58.0"
 export NODE_VM_IMAGE_TEMPLATE=${NODE_VM_IMAGE_TEMPLATE:-quay.io/capk/ubuntu-2004-container-disk:v1.22.0}
 
 _default_bin_path=./hack/tools/bin
@@ -342,7 +342,6 @@ function kubevirtci::vm_matches {
 }
 
 kubevirtci::fetch_kubevirtci
-
 case ${_action} in
 "up")
 	kubevirtci::up


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Latest kubevirtci has retired k8s-1.23 provider which was still in use here. Updated provider to k8s-1.25. Also updated kubevirt version to 0.58.0 so that the templates don't generate failures with `networkInterfaceMultiqueue: true`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

