### PR TITLE
Support block mode in tenant cluster

### DIFF
--- a/hack/run-k8s-e2e.sh
+++ b/hack/run-k8s-e2e.sh
@@ -73,6 +73,14 @@ spec:
   containers:
   - name: test-suite
     image: registry.access.redhat.com/ubi8/ubi:8.0
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: "RuntimeDefault"
     env:
     - name: KUBECONFIG
       value: /etc/kubernetes/kubeconfig/value

--- a/hack/test-driver.yaml
+++ b/hack/test-driver.yaml
@@ -6,7 +6,7 @@ SnapshotClass:
 DriverInfo:
   Name: csi.kubevirt.io
   Capabilities:
-    block: false
+    block: true
     controllerExpansion: false
     exec: true
     fsGroup: false

--- a/hack/test-driver.yaml
+++ b/hack/test-driver.yaml
@@ -17,6 +17,9 @@ DriverInfo:
     snapshotDataSource: false
     topology: false
     capacity: false
+  SupportedFsType:
+    ext4: {}
+    xfs: {}
 InlineVolumes:
 - shared: false
 

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -101,10 +101,6 @@ func (c *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	// Prepare parameters for the DataVolume
 	storageClassName := req.Parameters[infraStorageClassNameParameter]
-	volumeMode := getVolumeModeFromRequest(req)
-	if volumeMode == corev1.PersistentVolumeBlock {
-		return nil, status.Error(codes.InvalidArgument, "block mode not supported")
-	}
 	storageSize := req.GetCapacityRange().GetRequiredBytes()
 	dvName := req.Name
 	value, ok := req.Parameters[busParameter]
@@ -437,21 +433,4 @@ func (c *ControllerService) getVMNameByCSINodeID(nodeID string) (string, error) 
 	}
 
 	return "", status.Error(codes.NotFound, fmt.Sprintf("failed to find VM with domain.firmware.uuid %v", nodeID))
-}
-
-func getVolumeModeFromRequest(req *csi.CreateVolumeRequest) corev1.PersistentVolumeMode {
-	volumeMode := corev1.PersistentVolumeFilesystem // Set default in case not found in request
-
-	for _, cap := range req.VolumeCapabilities {
-		if cap == nil {
-			continue
-		}
-
-		if _, ok := cap.GetAccessType().(*csi.VolumeCapability_Block); ok {
-			volumeMode = corev1.PersistentVolumeBlock
-			break
-		}
-	}
-
-	return volumeMode
 }

--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -285,11 +285,16 @@ func (n *NodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 		return nil, err
 	}
 
-	klog.Infof("Unmounting %s", req.GetTargetPath())
-	err := n.mounter.Unmount(req.GetTargetPath())
+	targetPath := req.GetTargetPath()
+	klog.Infof("Unmounting %s", targetPath)
+	err := n.mounter.Unmount(targetPath)
 	if err != nil {
 		klog.Infof("failed to unmount")
 		return nil, err
+	}
+
+	if err = os.RemoveAll(targetPath); err != nil {
+		return nil, fmt.Errorf("remove target path: %w", err)
 	}
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil

--- a/pkg/service/service_suite_test.go
+++ b/pkg/service/service_suite_test.go
@@ -43,7 +43,7 @@ var _ = Describe("NodeService", func() {
 		underTest.dirMaker = dirMakerFunc(func(string, os.FileMode) error {
 			return nil
 		})
-		underTest.fsMounter = successfulMounter{}
+		underTest.mounter = successfulMounter{}
 	})
 
 	Describe("Staging a volume", func() {
@@ -58,8 +58,8 @@ var _ = Describe("NodeService", func() {
 		})
 
 		Context("With Block mode", func() {
-			It("should fail", func() {
-				_, err := underTest.NodeStageVolume(context.TODO(), &csi.NodeStageVolumeRequest{
+			It("should succeed", func() {
+				res, err := underTest.NodeStageVolume(context.TODO(), &csi.NodeStageVolumeRequest{
 					VolumeId: "pvc-123",
 					VolumeCapability: &csi.VolumeCapability{
 						AccessType: &csi.VolumeCapability_Block{
@@ -69,7 +69,8 @@ var _ = Describe("NodeService", func() {
 					VolumeContext:     map[string]string{serialParameter: serialID},
 					StagingTargetPath: "/invalid/staging",
 				})
-				Expect(err).To(HaveOccurred())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res).ToNot(BeNil())
 			})
 		})
 
@@ -143,7 +144,7 @@ var _ = Describe("NodeService", func() {
 
 		Context("With matching serial ID and failing mount", func() {
 			It("should fail", func() {
-				underTest.fsMounter = failingMounter{}
+				underTest.mounter = failingMounter{}
 				res, err := underTest.NodePublishVolume(context.TODO(), newPublishRequest())
 				Expect(err).To(HaveOccurred())
 				Expect(res).To(BeNil())
@@ -162,7 +163,7 @@ var _ = Describe("NodeService", func() {
 	Describe("Un-Publishing a volume", func() {
 		Context("With failing umount", func() {
 			It("should fail", func() {
-				underTest.fsMounter = failingMounter{}
+				underTest.mounter = failingMounter{}
 				res, err := underTest.NodeUnpublishVolume(context.TODO(), &csi.NodeUnpublishVolumeRequest{
 					VolumeId: "pvc-123",
 				})


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added support for block mode in tenant cluster.
Added functional test for block mode
Enabled block in k8s e2e suite

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #64 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Block volumes in tenant cluster
```

