### PR TITLE
Ensure volume is hotplugged before returning ControllerPublishVolume

### DIFF
--- a/deploy/infra-cluster-service-account.yaml
+++ b/deploy/infra-cluster-service-account.yaml
@@ -13,7 +13,7 @@ rules:
   verbs: ["get", "create", "delete"]
 - apiGroups: ["kubevirt.io"]
   resources: ["virtualmachineinstances"]
-  verbs: ["list"]
+  verbs: ["list", "get"]
 - apiGroups: ["subresources.kubevirt.io"]
   resources: ["virtualmachineinstances/addvolume", "virtualmachineinstances/removevolume"]
   verbs: ["update"]

--- a/e2e/create-pvc_test.go
+++ b/e2e/create-pvc_test.go
@@ -383,7 +383,12 @@ func runPod(client v1.CoreV1Interface, namespace string, pod *k8sv1.Pod) *k8sv1.
 		}
 		return nil
 	}, 3*time.Minute, 5*time.Second).Should(Succeed(), "Pod should reach Succeeded state")
-
+	//Ensure we don't see couldn't find device by serial id in pod event log.
+	events, err := client.Events(namespace).List(context.Background(), metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", newPod.Name), TypeMeta: metav1.TypeMeta{Kind: "Pod"}})
+	Expect(err).ToNot(HaveOccurred())
+	for _, event := range events.Items {
+		Expect(event.Message).ToNot(ContainSubstring("find device by serial id"))
+	}
 	return newPod
 }
 

--- a/hack/run-k8s-e2e.sh
+++ b/hack/run-k8s-e2e.sh
@@ -86,6 +86,7 @@ spec:
     - /bin/bash
     - -c
     - |
+      cd /tmp
       curl --location https://dl.k8s.io/v1.22.0/kubernetes-test-linux-amd64.tar.gz |   tar --strip-components=3 -zxf - kubernetes/test/bin/e2e.test kubernetes/test/bin/ginkgo
       chmod +x e2e.test
       curl -LO "https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl"

--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -124,7 +124,7 @@ func (n *NodeService) NodeStageVolume(_ context.Context, req *csi.NodeStageVolum
 
 	device, err := getDeviceBySerialID(req.VolumeContext[serialParameter], n.deviceLister)
 	if err != nil {
-		klog.Errorf("Failed to fetch device by serialID %s", req.VolumeId)
+		klog.Errorf("failed to fetch device by serialID %s", req.VolumeId)
 		return nil, err
 	}
 
@@ -139,7 +139,7 @@ func (n *NodeService) NodeStageVolume(_ context.Context, req *csi.NodeStageVolum
 	klog.Infof("Creating FS %s on device %s", fsType, device)
 	err = n.fsMaker.Make(device.Path, fsType)
 	if err != nil {
-		klog.Errorf("Could not create filesystem %s on %s", fsType, device)
+		klog.Errorf("could not create filesystem %s on %s", fsType, device)
 		return nil, err
 	}
 
@@ -215,7 +215,7 @@ func (n *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// TODO link to kubevirt code
 	device, err := getDeviceBySerialID(req.VolumeContext[serialParameter], n.deviceLister)
 	if err != nil {
-		klog.Errorf("Failed to fetch device by serialID %s ", req.VolumeId)
+		klog.Errorf("failed to fetch device by serialID %s ", req.VolumeId)
 		return nil, err
 	}
 
@@ -244,7 +244,7 @@ func (n *NodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		device, targetPath, fsType)
 	err = n.fsMounter.Mount(device.Path, targetPath, fsType, []string{})
 	if err != nil {
-		klog.Errorf("Failed mounting %v", err)
+		klog.Errorf("failed mounting %v", err)
 		return nil, err
 	}
 
@@ -273,7 +273,7 @@ func (n *NodeService) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	klog.Infof("Unmounting %s", req.GetTargetPath())
 	err := n.fsMounter.Unmount(req.GetTargetPath())
 	if err != nil {
-		klog.Infof("Failed to unmount")
+		klog.Infof("failed to unmount")
 		return nil, err
 	}
 
@@ -337,7 +337,7 @@ func getDeviceBySerialID(serialID string, deviceLister DeviceLister) (device, er
 	devices := devices{}
 	err = json.Unmarshal(out, &devices)
 	if err != nil {
-		klog.Errorf("Failed to parse json output from lsblk: %s", err)
+		klog.Errorf("failed to parse json output from lsblk: %s", err)
 		return device{}, err
 	}
 

--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -111,6 +112,11 @@ func (k *fakeKubeVirtClient) ListVirtualMachines(namespace string) ([]kubevirtv1
 	return res, nil
 }
 
+func (k *fakeKubeVirtClient) GetVirtualMachine(namespace, vmName string) (*kubevirtv1.VirtualMachineInstance, error) {
+	vmKey := getKey(namespace, vmName)
+	return k.vmiMap[vmKey], nil
+}
+
 func (k *fakeKubeVirtClient) DeleteDataVolume(namespace string, name string) error {
 	key := getKey(namespace, name)
 	delete(k.dvMap, key)
@@ -153,6 +159,10 @@ func (k *fakeKubeVirtClient) RemoveVolumeFromVM(namespace string, vmName string,
 		return fmt.Errorf("VM %s/%s not found", namespace, vmName)
 	}
 	delete(k.hotpluggedMap, hotPlugRequest.Name)
+	return nil
+}
+
+func (k *fakeKubeVirtClient) EnsureVolumeAvailable(namespace, vmName, volumeName string, timeout time.Duration) error {
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Sometimes pods would generate events noting the volume could not be mounted due to not finding it by serial. This was because the code was not waiting for the volume to be fully hotplugged into the node before returning. This caused an attempt to stage the volume on the node before the volume was fully attached.

Modified some error messages to not start with Upper case per golang error message guidelines.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

