### PR TITLE
Ensure volume is removed before returning success

### DIFF
--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -341,6 +341,12 @@ func (c *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 			return nil, err
 		}
 	}
+	err = c.virtClient.EnsureVolumeRemoved(c.infraClusterNamespace, vmName, dvName, time.Minute*2)
+	if err != nil {
+		klog.Errorf("volume %s failed to be removed in time from VM %s, %v", dvName, vmName, err)
+		return nil, err
+	}
+
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 

--- a/pkg/service/controller_test.go
+++ b/pkg/service/controller_test.go
@@ -363,3 +363,7 @@ func (c *ControllerClientMock) RemoveVolumeFromVM(namespace string, vmName strin
 func (c *ControllerClientMock) EnsureVolumeAvailable(namespace, vmName, volumeName string, timeout time.Duration) error {
 	return nil
 }
+
+func (c *ControllerClientMock) EnsureVolumeRemoved(namespace, vmName, volumeName string, timeout time.Duration) error {
+	return nil
+}

--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -163,6 +163,10 @@ func (k *fakeKubeVirtClient) RemoveVolumeFromVM(namespace string, vmName string,
 }
 
 func (k *fakeKubeVirtClient) EnsureVolumeAvailable(namespace, vmName, volumeName string, timeout time.Duration) error {
+	return nil
+}
+
+func (k *fakeKubeVirtClient) EnsureVolumeRemoved(namespace, vmName, volumeName string, timeout time.Duration) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When removing a volume from a VM, ensure that the volume is actually removed from the VM before returning nil from the ControllerUnpublishVolume function.
Added EnsureVolumeRemoved function to virtClient

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

