### PR TITLE
Increase timeout of csi-provisioner and csi attacher

### DIFF
--- a/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+++ b/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"math/rand"
 	"os"
 	"strings"
-	"time"
 
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,11 +20,11 @@ import (
 )
 
 var (
-	endpoint                     = flag.String("endpoint", "unix:/csi/csi.sock", "CSI endpoint")
-	nodeName                     = flag.String("node-name", "", "The node name - the node this pods runs on")
-	infraClusterNamespace        = flag.String("infra-cluster-namespace", "", "The infra-cluster namespace")
-	infraClusterKubeconfig       = flag.String("infra-cluster-kubeconfig", "", "the infra-cluster kubeconfig file. If not set, defaults to in cluster config.")
-	infraClusterLabels           = flag.String("infra-cluster-labels", "", "The infra-cluster labels to use when creating resources in infra cluster. 'name=value' fields separated by a comma")
+	endpoint               = flag.String("endpoint", "unix:/csi/csi.sock", "CSI endpoint")
+	nodeName               = flag.String("node-name", "", "The node name - the node this pods runs on")
+	infraClusterNamespace  = flag.String("infra-cluster-namespace", "", "The infra-cluster namespace")
+	infraClusterKubeconfig = flag.String("infra-cluster-kubeconfig", "", "the infra-cluster kubeconfig file. If not set, defaults to in cluster config.")
+	infraClusterLabels     = flag.String("infra-cluster-labels", "", "The infra-cluster labels to use when creating resources in infra cluster. 'name=value' fields separated by a comma")
 	// infraStorageClassEnforcement = flag.String("infra-storage-class-enforcement", "", "A string encoded yaml that represents the policy of enforcing which infra storage classes are allowed in persistentVolume of type kubevirt")
 	infraStorageClassEnforcement = os.Getenv("INFRA_STORAGE_CLASS_ENFORCEMENT")
 
@@ -60,7 +58,6 @@ func init() {
 
 func main() {
 	flag.Parse()
-	rand.Seed(time.Now().UnixNano())
 	handle()
 	os.Exit(0)
 }

--- a/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+++ b/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,6 +60,7 @@ func init() {
 
 func main() {
 	flag.Parse()
+	rand.Seed(time.Now().UnixNano())
 	handle()
 	os.Exit(0)
 }

--- a/deploy/controller-infra/base/deploy.yaml
+++ b/deploy/controller-infra/base/deploy.yaml
@@ -36,7 +36,7 @@ spec:
             - "--tenant-cluster-kubeconfig=/var/run/secrets/tenantcluster/value"
             - "--run-node-service=false"
             - "--run-controller-service=true"
-            - --v=5
+            - "--v=5"
           ports:
             - name: healthz
               containerPort: 10301
@@ -76,10 +76,11 @@ spec:
         - name: csi-provisioner
           image: quay.io/openshift/origin-csi-external-provisioner:latest
           args:
-            - --csi-address=$(ADDRESS)
-            - --default-fstype=ext4
-            - --kubeconfig=/var/run/secrets/tenantcluster/value
-            - --v=5
+            - "--csi-address=$(ADDRESS)"
+            - "--default-fstype=ext4"
+            - "--kubeconfig=/var/run/secrets/tenantcluster/value"
+            - "--v=5"
+            - "--timeout=3m"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -91,9 +92,11 @@ spec:
         - name: csi-attacher
           image: quay.io/openshift/origin-csi-external-attacher:latest
           args:
-            - --csi-address=$(ADDRESS)
-            - --kubeconfig=/var/run/secrets/tenantcluster/value
-            - --v=5
+            - "--csi-address=$(ADDRESS)"
+            - "--kubeconfig=/var/run/secrets/tenantcluster/value"
+            - "--v=5"
+            - "--timeout=3m"
+            - "--retry-interval-max=1m"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -109,9 +112,9 @@ spec:
         - name: csi-liveness-probe
           image: quay.io/openshift/origin-csi-livenessprobe:latest
           args:
-            - --csi-address=/csi/csi.sock
-            - --probe-timeout=3s
-            - --health-port=10301
+            - "--csi-address=/csi/csi.sock"
+            - "--probe-timeout=3s"
+            - "--health-port=10301"
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/deploy/controller-infra/base/deploy.yaml
+++ b/deploy/controller-infra/base/deploy.yaml
@@ -81,6 +81,7 @@ spec:
             - "--kubeconfig=/var/run/secrets/tenantcluster/value"
             - "--v=5"
             - "--timeout=3m"
+            - "--retry-interval-max=1m"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/tenant/base/deploy.yaml
+++ b/deploy/tenant/base/deploy.yaml
@@ -169,6 +169,7 @@ spec:
             - "--node-name=$(KUBE_NODE_NAME)"
             - "--run-node-service=true"
             - "--run-controller-service=false"
+            - "--v=5"
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -203,9 +204,9 @@ spec:
         - name: csi-node-driver-registrar
           image: quay.io/openshift/origin-csi-node-driver-registrar:latest
           args:
-            - --csi-address=$(ADDRESS)
-            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v=5
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+            - "--v=5"
           lifecycle:
             preStop:
               exec:
@@ -227,9 +228,9 @@ spec:
         - name: csi-liveness-probe
           image: quay.io/openshift/origin-csi-livenessprobe:latest
           args:
-            - --csi-address=/csi/csi.sock
-            - --probe-timeout=3s
-            - --health-port=10300
+            - "--csi-address=/csi/csi.sock"
+            - "--probe-timeout=3s"
+            - "--health-port=10300"
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -68,7 +68,7 @@ func (c *client) RemoveVolumeFromVM(namespace string, vmName string, hotPlugRequ
 // EnsureVolumeAvailable checks to make sure the volume is available in the node before returning, checks for 2 minutes
 func (c *client) EnsureVolumeAvailable(namespace, vmName, volumeName string, timeout time.Duration) error {
 	return wait.PollImmediate(time.Second, timeout, func() (done bool, err error) {
-		vmi, err := c.virtClient.VirtualMachineInstance(namespace).Get(context.TODO(), vmName, &metav1.GetOptions{})
+		vmi, err := c.GetVirtualMachine(namespace, vmName)
 		if err != nil {
 			return false, err
 		}
@@ -85,7 +85,7 @@ func (c *client) EnsureVolumeAvailable(namespace, vmName, volumeName string, tim
 // EnsureVolumeAvailable checks to make sure the volume is available in the node before returning, checks for 2 minutes
 func (c *client) EnsureVolumeRemoved(namespace, vmName, volumeName string, timeout time.Duration) error {
 	return wait.PollImmediate(time.Second, timeout, func() (done bool, err error) {
-		vmi, err := c.virtClient.VirtualMachineInstance(namespace).Get(context.TODO(), vmName, &metav1.GetOptions{})
+		vmi, err := c.GetVirtualMachine(namespace, vmName)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -267,7 +267,12 @@ func (c *ControllerService) ControllerPublishVolume(
 		},
 	}
 
-	if err := wait.PollImmediate(time.Millisecond, time.Millisecond*6, func() (bool, error) {
+	if err := wait.ExponentialBackoff(wait.Backoff{
+		Duration: time.Second,
+		Steps:    5,
+		Factor:   2,
+		Cap:      time.Second * 30,
+	}, func() (bool, error) {
 		if err := c.addVolumeToVm(dvName, vmName, addVolumeOptions); err != nil {
 			klog.Infof("failed adding volume %s to VM %s, retrying, err: %v", dvName, vmName, err)
 			return false, nil
@@ -344,7 +349,12 @@ func (c *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 		return nil, err
 	}
 
-	if err := wait.PollImmediate(time.Millisecond, time.Millisecond*6, func() (bool, error) {
+	if err := wait.ExponentialBackoff(wait.Backoff{
+		Duration: time.Second,
+		Steps:    5,
+		Factor:   2,
+		Cap:      time.Second * 30,
+	}, func() (bool, error) {
 		if err := c.removeVolumeFromVm(dvName, vmName); err != nil {
 			klog.Infof("failed removing volume %s from VM %s, err: %v", dvName, vmName, err)
 			return false, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Increased timeout of csi-provisioner and csi-attacher. This fixes random failures in the k8s e2e test. Cleaned up some linter issues with using deprecated functions.
Ignore server rejection errors from kubevirt addvolume/removevolume and retry them.
Put proper log levels on messages so it is easier to control the
logging in the csi-driver pod. Added some extra logging to easier identify issues once the log level is set high enough.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
See these links for what the arguments do
https://github.com/kubernetes-csi/external-provisioner
https://github.com/kubernetes-csi/external-attacher


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increased timeout for csi-provisioner and csi-attacher
```

