### PR TITLE
Use context when calling KV client 

### DIFF
--- a/pkg/kubevirt/mocked_client.go
+++ b/pkg/kubevirt/mocked_client.go
@@ -7,6 +7,7 @@ package kubevirt
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "kubevirt.io/api/core/v1"
@@ -37,61 +38,119 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AddVolumeToVM mocks base method.
-func (m *MockClient) AddVolumeToVM(namespace, vmName string, hotPlugRequest *v1.AddVolumeOptions) error {
+func (m *MockClient) AddVolumeToVM(ctx context.Context, namespace, vmName string, hotPlugRequest *v1.AddVolumeOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddVolumeToVM", namespace, vmName, hotPlugRequest)
+	ret := m.ctrl.Call(m, "AddVolumeToVM", ctx, namespace, vmName, hotPlugRequest)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddVolumeToVM indicates an expected call of AddVolumeToVM.
-func (mr *MockClientMockRecorder) AddVolumeToVM(namespace, vmName, hotPlugRequest interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) AddVolumeToVM(ctx, namespace, vmName, hotPlugRequest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddVolumeToVM", reflect.TypeOf((*MockClient)(nil).AddVolumeToVM), namespace, vmName, hotPlugRequest)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddVolumeToVM", reflect.TypeOf((*MockClient)(nil).AddVolumeToVM), ctx, namespace, vmName, hotPlugRequest)
 }
 
 // CreateDataVolume mocks base method.
-func (m *MockClient) CreateDataVolume(namespace string, dataVolume *v1beta1.DataVolume) (*v1beta1.DataVolume, error) {
+func (m *MockClient) CreateDataVolume(ctx context.Context, namespace string, dataVolume *v1beta1.DataVolume) (*v1beta1.DataVolume, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDataVolume", namespace, dataVolume)
+	ret := m.ctrl.Call(m, "CreateDataVolume", ctx, namespace, dataVolume)
 	ret0, _ := ret[0].(*v1beta1.DataVolume)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateDataVolume indicates an expected call of CreateDataVolume.
-func (mr *MockClientMockRecorder) CreateDataVolume(namespace, dataVolume interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) CreateDataVolume(ctx, namespace, dataVolume interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDataVolume", reflect.TypeOf((*MockClient)(nil).CreateDataVolume), namespace, dataVolume)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDataVolume", reflect.TypeOf((*MockClient)(nil).CreateDataVolume), ctx, namespace, dataVolume)
 }
 
 // DeleteDataVolume mocks base method.
-func (m *MockClient) DeleteDataVolume(namespace, name string) error {
+func (m *MockClient) DeleteDataVolume(ctx context.Context, namespace, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDataVolume", namespace, name)
+	ret := m.ctrl.Call(m, "DeleteDataVolume", ctx, namespace, name)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteDataVolume indicates an expected call of DeleteDataVolume.
-func (mr *MockClientMockRecorder) DeleteDataVolume(namespace, name interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) DeleteDataVolume(ctx, namespace, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDataVolume", reflect.TypeOf((*MockClient)(nil).DeleteDataVolume), namespace, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDataVolume", reflect.TypeOf((*MockClient)(nil).DeleteDataVolume), ctx, namespace, name)
+}
+
+// EnsureVolumeAvailable mocks base method.
+func (m *MockClient) EnsureVolumeAvailable(ctx context.Context, namespace, vmName, volumeName string, timeout time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureVolumeAvailable", ctx, namespace, vmName, volumeName, timeout)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureVolumeAvailable indicates an expected call of EnsureVolumeAvailable.
+func (mr *MockClientMockRecorder) EnsureVolumeAvailable(ctx, namespace, vmName, volumeName, timeout interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureVolumeAvailable", reflect.TypeOf((*MockClient)(nil).EnsureVolumeAvailable), ctx, namespace, vmName, volumeName, timeout)
+}
+
+// EnsureVolumeRemoved mocks base method.
+func (m *MockClient) EnsureVolumeRemoved(ctx context.Context, namespace, vmName, volumeName string, timeout time.Duration) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureVolumeRemoved", ctx, namespace, vmName, volumeName, timeout)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureVolumeRemoved indicates an expected call of EnsureVolumeRemoved.
+func (mr *MockClientMockRecorder) EnsureVolumeRemoved(ctx, namespace, vmName, volumeName, timeout interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureVolumeRemoved", reflect.TypeOf((*MockClient)(nil).EnsureVolumeRemoved), ctx, namespace, vmName, volumeName, timeout)
+}
+
+// GetDataVolume mocks base method.
+func (m *MockClient) GetDataVolume(ctx context.Context, namespace, name string) (*v1beta1.DataVolume, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDataVolume", ctx, namespace, name)
+	ret0, _ := ret[0].(*v1beta1.DataVolume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDataVolume indicates an expected call of GetDataVolume.
+func (mr *MockClientMockRecorder) GetDataVolume(ctx, namespace, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataVolume", reflect.TypeOf((*MockClient)(nil).GetDataVolume), ctx, namespace, name)
+}
+
+// GetVirtualMachine mocks base method.
+func (m *MockClient) GetVirtualMachine(ctx context.Context, namespace, name string) (*v1.VirtualMachineInstance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVirtualMachine", ctx, namespace, name)
+	ret0, _ := ret[0].(*v1.VirtualMachineInstance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVirtualMachine indicates an expected call of GetVirtualMachine.
+func (mr *MockClientMockRecorder) GetVirtualMachine(ctx, namespace, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualMachine", reflect.TypeOf((*MockClient)(nil).GetVirtualMachine), ctx, namespace, name)
 }
 
 // ListVirtualMachines mocks base method.
-func (m *MockClient) ListVirtualMachines(namespace string) ([]v1.VirtualMachineInstance, error) {
+func (m *MockClient) ListVirtualMachines(ctx context.Context, namespace string) ([]v1.VirtualMachineInstance, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListVirtualMachines", namespace)
+	ret := m.ctrl.Call(m, "ListVirtualMachines", ctx, namespace)
 	ret0, _ := ret[0].([]v1.VirtualMachineInstance)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListVirtualMachines indicates an expected call of ListVirtualMachines.
-func (mr *MockClientMockRecorder) ListVirtualMachines(namespace interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ListVirtualMachines(ctx, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualMachines", reflect.TypeOf((*MockClient)(nil).ListVirtualMachines), namespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualMachines", reflect.TypeOf((*MockClient)(nil).ListVirtualMachines), ctx, namespace)
 }
 
 // Ping mocks base method.
@@ -109,15 +168,15 @@ func (mr *MockClientMockRecorder) Ping(ctx interface{}) *gomock.Call {
 }
 
 // RemoveVolumeFromVM mocks base method.
-func (m *MockClient) RemoveVolumeFromVM(namespace, vmName string, hotPlugRequest *v1.RemoveVolumeOptions) error {
+func (m *MockClient) RemoveVolumeFromVM(ctx context.Context, namespace, vmName string, hotPlugRequest *v1.RemoveVolumeOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveVolumeFromVM", namespace, vmName, hotPlugRequest)
+	ret := m.ctrl.Call(m, "RemoveVolumeFromVM", ctx, namespace, vmName, hotPlugRequest)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveVolumeFromVM indicates an expected call of RemoveVolumeFromVM.
-func (mr *MockClientMockRecorder) RemoveVolumeFromVM(namespace, vmName, hotPlugRequest interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) RemoveVolumeFromVM(ctx, namespace, vmName, hotPlugRequest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVolumeFromVM", reflect.TypeOf((*MockClient)(nil).RemoveVolumeFromVM), namespace, vmName, hotPlugRequest)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVolumeFromVM", reflect.TypeOf((*MockClient)(nil).RemoveVolumeFromVM), ctx, namespace, vmName, hotPlugRequest)
 }

--- a/pkg/service/controller_test.go
+++ b/pkg/service/controller_test.go
@@ -248,7 +248,7 @@ func (c *ControllerClientMock) ListNamespace(ctx context.Context) (*corev1.Names
 func (c *ControllerClientMock) GetStorageClass(ctx context.Context, name string) (*storagev1.StorageClass, error) {
 	return nil, errors.New("Not implemented")
 }
-func (c *ControllerClientMock) ListVirtualMachines(namespace string) ([]kubevirtv1.VirtualMachineInstance, error) {
+func (c *ControllerClientMock) ListVirtualMachines(_ context.Context, namespace string) ([]kubevirtv1.VirtualMachineInstance, error) {
 	if c.FailListVirtualMachines {
 		return nil, errors.New("ListVirtualMachines failed")
 	}
@@ -270,7 +270,7 @@ func (c *ControllerClientMock) ListVirtualMachines(namespace string) ([]kubevirt
 	}, nil
 }
 
-func (c *ControllerClientMock) GetVirtualMachine(namespace, name string) (*kubevirtv1.VirtualMachineInstance, error) {
+func (c *ControllerClientMock) GetVirtualMachine(_ context.Context, namespace, name string) (*kubevirtv1.VirtualMachineInstance, error) {
 	if c.FailListVirtualMachines {
 		return nil, errors.New("ListVirtualMachines failed")
 	}
@@ -291,7 +291,7 @@ func (c *ControllerClientMock) GetVirtualMachine(namespace, name string) (*kubev
 	}, nil
 }
 
-func (c *ControllerClientMock) DeleteDataVolume(namespace string, name string) error {
+func (c *ControllerClientMock) DeleteDataVolume(_ context.Context, namespace string, name string) error {
 	if c.FailDeleteDataVolume {
 		return errors.New("DeleteDataVolume failed")
 	}
@@ -301,7 +301,7 @@ func (c *ControllerClientMock) DeleteDataVolume(namespace string, name string) e
 
 	return nil
 }
-func (c *ControllerClientMock) CreateDataVolume(namespace string, dataVolume *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+func (c *ControllerClientMock) CreateDataVolume(_ context.Context, namespace string, dataVolume *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
 	if c.FailCreateDataVolume {
 		return nil, errors.New("CreateDataVolume failed")
 	}
@@ -319,22 +319,22 @@ func (c *ControllerClientMock) CreateDataVolume(namespace string, dataVolume *cd
 	assert.Equal(c.t, testInfraLabels, dataVolume.Labels)
 
 	// Input OK. Now prepare result
-	result := &cdiv1.DataVolume{}
+	result := dataVolume.DeepCopy()
 
 	result.SetUID(types.UID(testDataVolumeUID))
 
 	return result, nil
 }
-func (c *ControllerClientMock) GetDataVolume(namespace string, name string) (*cdiv1.DataVolume, error) {
+func (c *ControllerClientMock) GetDataVolume(_ context.Context, namespace string, name string) (*cdiv1.DataVolume, error) {
 	return nil, k8serrors.NewNotFound(cdiv1.Resource("DataVolume"), name)
 }
-func (c *ControllerClientMock) ListDataVolumes(namespace string) ([]cdiv1.DataVolume, error) {
+func (c *ControllerClientMock) ListDataVolumes(_ context.Context, namespace string) ([]cdiv1.DataVolume, error) {
 	return nil, errors.New("Not implemented")
 }
 func (c *ControllerClientMock) GetVMI(ctx context.Context, namespace string, name string) (*kubevirtv1.VirtualMachineInstance, error) {
 	return nil, errors.New("Not implemented")
 }
-func (c *ControllerClientMock) AddVolumeToVM(namespace string, vmName string, addVolumeOptions *kubevirtv1.AddVolumeOptions) error {
+func (c *ControllerClientMock) AddVolumeToVM(_ context.Context, namespace string, vmName string, addVolumeOptions *kubevirtv1.AddVolumeOptions) error {
 	if c.FailAddVolumeToVM {
 		return errors.New("AddVolumeToVM failed")
 	}
@@ -348,7 +348,7 @@ func (c *ControllerClientMock) AddVolumeToVM(namespace string, vmName string, ad
 
 	return nil
 }
-func (c *ControllerClientMock) RemoveVolumeFromVM(namespace string, vmName string, removeVolumeOptions *kubevirtv1.RemoveVolumeOptions) error {
+func (c *ControllerClientMock) RemoveVolumeFromVM(_ context.Context, namespace string, vmName string, removeVolumeOptions *kubevirtv1.RemoveVolumeOptions) error {
 	if c.FailRemoveVolumeFromVM {
 		return errors.New("RemoveVolumeFromVM failed")
 	}
@@ -360,10 +360,10 @@ func (c *ControllerClientMock) RemoveVolumeFromVM(namespace string, vmName strin
 	return nil
 }
 
-func (c *ControllerClientMock) EnsureVolumeAvailable(namespace, vmName, volumeName string, timeout time.Duration) error {
+func (c *ControllerClientMock) EnsureVolumeAvailable(_ context.Context, namespace, vmName, volumeName string, timeout time.Duration) error {
 	return nil
 }
 
-func (c *ControllerClientMock) EnsureVolumeRemoved(namespace, vmName, volumeName string, timeout time.Duration) error {
+func (c *ControllerClientMock) EnsureVolumeRemoved(_ context.Context, namespace, vmName, volumeName string, timeout time.Duration) error {
 	return nil
 }

--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -102,7 +102,7 @@ type fakeKubeVirtClient struct {
 func (k *fakeKubeVirtClient) Ping(ctx context.Context) error {
 	return nil
 }
-func (k *fakeKubeVirtClient) ListVirtualMachines(namespace string) ([]kubevirtv1.VirtualMachineInstance, error) {
+func (k *fakeKubeVirtClient) ListVirtualMachines(_ context.Context, namespace string) ([]kubevirtv1.VirtualMachineInstance, error) {
 	var res []kubevirtv1.VirtualMachineInstance
 	for _, v := range k.vmiMap {
 		if v != nil {
@@ -112,18 +112,18 @@ func (k *fakeKubeVirtClient) ListVirtualMachines(namespace string) ([]kubevirtv1
 	return res, nil
 }
 
-func (k *fakeKubeVirtClient) GetVirtualMachine(namespace, vmName string) (*kubevirtv1.VirtualMachineInstance, error) {
+func (k *fakeKubeVirtClient) GetVirtualMachine(_ context.Context, namespace, vmName string) (*kubevirtv1.VirtualMachineInstance, error) {
 	vmKey := getKey(namespace, vmName)
 	return k.vmiMap[vmKey], nil
 }
 
-func (k *fakeKubeVirtClient) DeleteDataVolume(namespace string, name string) error {
+func (k *fakeKubeVirtClient) DeleteDataVolume(_ context.Context, namespace string, name string) error {
 	key := getKey(namespace, name)
 	delete(k.dvMap, key)
 	return nil
 }
 
-func (k *fakeKubeVirtClient) GetDataVolume(namespace string, name string) (*cdiv1.DataVolume, error) {
+func (k *fakeKubeVirtClient) GetDataVolume(_ context.Context, namespace string, name string) (*cdiv1.DataVolume, error) {
 	key := getKey(namespace, name)
 	if k.dvMap[key] == nil {
 		return nil, errors.NewNotFound(cdiv1.Resource("DataVolume"), name)
@@ -131,7 +131,7 @@ func (k *fakeKubeVirtClient) GetDataVolume(namespace string, name string) (*cdiv
 	return k.dvMap[key], nil
 }
 
-func (k *fakeKubeVirtClient) CreateDataVolume(namespace string, dataVolume *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
+func (k *fakeKubeVirtClient) CreateDataVolume(_ context.Context, namespace string, dataVolume *cdiv1.DataVolume) (*cdiv1.DataVolume, error) {
 	if dataVolume == nil {
 		return nil, fmt.Errorf("Nil datavolume passed")
 	}
@@ -140,7 +140,7 @@ func (k *fakeKubeVirtClient) CreateDataVolume(namespace string, dataVolume *cdiv
 	k.dvMap[key] = dataVolume
 	return dataVolume, nil
 }
-func (k *fakeKubeVirtClient) AddVolumeToVM(namespace string, vmName string, hotPlugRequest *kubevirtv1.AddVolumeOptions) error {
+func (k *fakeKubeVirtClient) AddVolumeToVM(_ context.Context, namespace string, vmName string, hotPlugRequest *kubevirtv1.AddVolumeOptions) error {
 	vmKey := getKey(namespace, vmName)
 	if k.vmiMap[vmKey] == nil {
 		return fmt.Errorf("VM %s/%s not found", namespace, vmName)
@@ -153,7 +153,7 @@ func (k *fakeKubeVirtClient) AddVolumeToVM(namespace string, vmName string, hotP
 	return nil
 }
 
-func (k *fakeKubeVirtClient) RemoveVolumeFromVM(namespace string, vmName string, hotPlugRequest *kubevirtv1.RemoveVolumeOptions) error {
+func (k *fakeKubeVirtClient) RemoveVolumeFromVM(_ context.Context, namespace string, vmName string, hotPlugRequest *kubevirtv1.RemoveVolumeOptions) error {
 	vmKey := getKey(namespace, vmName)
 	if k.vmiMap[vmKey] == nil {
 		return fmt.Errorf("VM %s/%s not found", namespace, vmName)
@@ -162,11 +162,11 @@ func (k *fakeKubeVirtClient) RemoveVolumeFromVM(namespace string, vmName string,
 	return nil
 }
 
-func (k *fakeKubeVirtClient) EnsureVolumeAvailable(namespace, vmName, volumeName string, timeout time.Duration) error {
+func (k *fakeKubeVirtClient) EnsureVolumeAvailable(_ context.Context, namespace, vmName, volumeName string, timeout time.Duration) error {
 	return nil
 }
 
-func (k *fakeKubeVirtClient) EnsureVolumeRemoved(namespace, vmName, volumeName string, timeout time.Duration) error {
+func (k *fakeKubeVirtClient) EnsureVolumeRemoved(_ context.Context, namespace, vmName, volumeName string, timeout time.Duration) error {
 	return nil
 }
 


### PR DESCRIPTION
The current code creates a TODO context instead of passing the context
from the request.

This PR changes the code to use the context from the request, so it will
support potential cancellation or timeout.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

