### PR TITLE
Update kubevirtci to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ TAG ?= latest
 IMAGE_REF=$(REGISTRY)/$(TARGET_NAME):$(TAG)
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 IMAGE_REGISTRY?=registry.svc.ci.openshift.org
-KUBEVIRT_PROVIDER?=k8s-1.26
 SHA := $(shell git describe --no-match  --always --abbrev=40 --dirty)
 BIN_DIR := bin
 

--- a/deploy/controller-tenant/base/deploy.yaml
+++ b/deploy/controller-tenant/base/deploy.yaml
@@ -17,11 +17,14 @@ spec:
       serviceAccount: kubevirt-csi-controller-sa
       priorityClassName: system-cluster-critical
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
         - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: "NoSchedule"
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"
       containers:

--- a/e2e/create-pvc_test.go
+++ b/e2e/create-pvc_test.go
@@ -355,11 +355,18 @@ func podWithoutPVCSpec(podName string, cmd, args []string) *k8sv1.Pod {
 				},
 			},
 			// add toleration so we can use control node for tests
-			Tolerations: []k8sv1.Toleration{{
-				Key:      "node-role.kubernetes.io/master",
-				Operator: k8sv1.TolerationOpExists,
-				Effect:   k8sv1.TaintEffectNoSchedule,
-			}},
+			Tolerations: []k8sv1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: k8sv1.TolerationOpExists,
+					Effect:   k8sv1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/control-plane",
+					Operator: k8sv1.TolerationOpExists,
+					Effect:   k8sv1.TaintEffectNoSchedule,
+				},
+			},
 		},
 	}
 }

--- a/hack/ci/e2e-latest-split.sh
+++ b/hack/ci/e2e-latest-split.sh
@@ -2,8 +2,6 @@
 
 set -ex
 
-export KUBEVIRT_PROVIDER=k8s-1.26
-
 make cluster-up
 make cluster-sync-split
 make e2e-test

--- a/hack/ci/e2e-latest.sh
+++ b/hack/ci/e2e-latest.sh
@@ -2,8 +2,6 @@
 
 set -ex
 
-export KUBEVIRT_PROVIDER=k8s-1.26
-
 make cluster-up
 make cluster-sync
 make e2e-test

--- a/hack/run-k8s-e2e.sh
+++ b/hack/run-k8s-e2e.sh
@@ -15,8 +15,7 @@
 set -e
 export TENANT_CLUSTER_NAME=${TENANT_CLUSTER_NAME:-kvcluster}
 export TENANT_CLUSTER_NAMESPACE=${TENANT_CLUSTER_NAMESPACE:-kvcluster}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2301240001-e641e98}
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.26}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2309141019-029e67a}
 
 test_pod=${TENANT_CLUSTER_NAME}-k8s-e2e-suite-runnner
 test_driver_cm=${TENANT_CLUSTER_NAME}-test-driver
@@ -61,6 +60,7 @@ function create_capk_secret {
     rm -f ./capk.pem || true
 }
 
+# In order to support ReadWriteOncePod, we need to install the resize side car which we are not using right now. See https://kubernetes.io/blog/2021/09/13/read-write-once-pod-access-mode-alpha/ for more info
 function start_test_pod {
 cat <<EOF | ./kubevirtci kubectl create -f -
 apiVersion: v1
@@ -95,12 +95,12 @@ spec:
     - -c
     - |
       cd /tmp
-      curl --location https://dl.k8s.io/v1.22.0/kubernetes-test-linux-amd64.tar.gz |   tar --strip-components=3 -zxf - kubernetes/test/bin/e2e.test kubernetes/test/bin/ginkgo
+      curl --location https://dl.k8s.io/v1.26.0/kubernetes-test-linux-amd64.tar.gz |   tar --strip-components=3 -zxf - kubernetes/test/bin/e2e.test kubernetes/test/bin/ginkgo
       chmod +x e2e.test
-      curl -LO "https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl"
+      curl -LO "https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl"
       chmod +x kubectl
       echo \$TEST_DRIVER_PATH
-      ./e2e.test -kubeconfig \${KUBECONFIG} -kubectl-path ./kubectl -ginkgo.v -ginkgo.focus='External.Storage.*csi.kubevirt.io.*' -ginkgo.skip='CSI Ephemeral-volume*' -storage.testdriver=\${TEST_DRIVER_PATH}/test-driver.yaml -provider=local -report-dir=/tmp
+      ./e2e.test -kubeconfig \${KUBECONFIG} -kubectl-path ./kubectl -ginkgo.v -ginkgo.focus='External.Storage.*csi.kubevirt.io.*' -ginkgo.skip='CSI Ephemeral-volume*' -ginkgo.skip='SELinuxMountReadWriteOncePod.*' -storage.testdriver=\${TEST_DRIVER_PATH}/test-driver.yaml -provider=local -report-dir=/tmp
       ret=\$?
       while [ ! -f /tmp/exit.txt ]; do
         sleep 2

--- a/kubevirtci
+++ b/kubevirtci
@@ -2,21 +2,20 @@
 
 set -e
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.26}
-export CAPK_GUEST_K8S_VERSION=${CAPK_GUEST_K8S_VERSION:-v1.22.0}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2301240001-e641e98}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.28}
+export CAPK_GUEST_K8S_VERSION=${CAPK_GUEST_K8S_VERSION:-v1.26.0}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2309141019-029e67a}
 export KUBECONFIG=$(cluster-up/cluster-up/kubeconfig.sh)
 export KUBEVIRT_DEPLOY_PROMETHEUS=false
-export KUBEVIRT_DEPLOY_CDI=false
 export KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 export KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-15360M}
 export KUBEVIRT_DEPLOY_CDI="true"
-export METALLB_VERSION="v0.12.1"
-export CAPK_RELEASE_VERSION="v0.1.6"
-export CLUSTERCTL_VERSION="v1.4.2"
-export CALICO_VERSION="v3.21"
-export KUBEVIRT_VERSION="v0.58.0"
-export NODE_VM_IMAGE_TEMPLATE=${NODE_VM_IMAGE_TEMPLATE:-quay.io/capk/ubuntu-2004-container-disk:v1.22.0}
+export METALLB_VERSION="v0.14.3"
+export CAPK_RELEASE_VERSION="v0.1.8"
+export CLUSTERCTL_VERSION="v1.6.1"
+export CALICO_VERSION="v3.27.0"
+export KUBEVIRT_VERSION="v1.1.1"
+export NODE_VM_IMAGE_TEMPLATE=${NODE_VM_IMAGE_TEMPLATE:-quay.io/capk/ubuntu-2004-container-disk:v1.26.0}
 
 _default_bin_path=./hack/tools/bin
 _default_tmp_path=./hack/tools/bin/tmp
@@ -96,11 +95,11 @@ function kubevirtci::up() {
 	${_kubectl} apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
 	${_kubectl} apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml
 	echo "installing capi..."
-
+#The version of the url needs to match what clusterctl is expecting.
 	cat << EOF > ${_default_bin_path}/clusterctl_config.yaml
 ---
 cert-manager:
-  url: "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"
+  url: "https://github.com/cert-manager/cert-manager/releases/1.13.2/cert-manager.yaml"
 EOF
 	$CLUSTERCTL_PATH init -v 4 --config=${_default_bin_path}/clusterctl_config.yaml
 	echo "waiting for kubevirt to become ready, this can take a few minutes. You can safely abort this step, the cluster is ready ..."
@@ -224,7 +223,7 @@ function kubevirtci::install_capk_release {
 
 
 function kubevirtci::install_calico {
-	kubevirtci::kubectl_tenant apply -f https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
+	kubevirtci::kubectl_tenant apply -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml
 	echo "Waiting for calico pods rollout"
 	kubevirtci::kubectl_tenant rollout status ds/calico-node -n kube-system --timeout=5m
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Run kubernetes 1.28 by default
Use kubevirt 1.1.1
Update the guest kubernetes to 1.26 by default
Update metallb to 0.14.3
Update clusterctl to 1.6.1
Update calico to 3.27.0
Update capk to 0.1.8

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

