### PR TITLE
Support Read Write Many (RWX) access mode with block

### DIFF
--- a/e2e/create-pvc_test.go
+++ b/e2e/create-pvc_test.go
@@ -8,25 +8,26 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/klog/v2"
-
-	"k8s.io/client-go/tools/clientcmd"
-	cdicli "kubevirt.io/csi-driver/pkg/generated/containerized-data-importer/client-go/clientset/versioned"
-	kubecli "kubevirt.io/csi-driver/pkg/generated/kubevirt/client-go/clientset/versioned"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"github.com/spf13/pflag"
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	cdicli "kubevirt.io/csi-driver/pkg/generated/containerized-data-importer/client-go/clientset/versioned"
+	kubecli "kubevirt.io/csi-driver/pkg/generated/kubevirt/client-go/clientset/versioned"
 )
+
+const hostNameLabelKey = "kubernetes.io/hostname"
 
 var virtClient *kubecli.Clientset
 
@@ -48,8 +49,6 @@ func defaultInfraClientConfig(flags *pflag.FlagSet) clientcmd.ClientConfig {
 }
 
 var _ = Describe("CreatePVC", func() {
-
-	const hostNameLabelKey = "kubernetes.io/hostname"
 
 	var tmpDir string
 	var tenantClient *kubernetes.Clientset
@@ -85,7 +84,7 @@ var _ = Describe("CreatePVC", func() {
 		_ = os.RemoveAll(tmpDir)
 	})
 
-	DescribeTable("creates a pvc and attaches to pod", Label("pvcCreation"), func(volumeMode k8sv1.PersistentVolumeMode, podCreationFunc func(string) *k8sv1.Pod) {
+	DescribeTable("creates a pvc and attaches to pod", Label("pvcCreation"), func(volumeMode k8sv1.PersistentVolumeMode, storageOpt storageOption, attachCmd string) {
 		pvcName := "test-pvc"
 		storageClassName := "kubevirt"
 		pvc := pvcSpec(pvcName, storageClassName, "10Mi")
@@ -96,16 +95,21 @@ var _ = Describe("CreatePVC", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("creating a pod that attaches pvc")
+		podSpec := createPod("test-pod",
+			withCommand(attachCmd),
+			storageOpt(pvc.Name))
+
 		runPod(
 			tenantClient.CoreV1(),
 			namespace,
-			podCreationFunc(pvc.Name))
+			podSpec,
+			true)
 	},
-		Entry("Filesystem volume mode", k8sv1.PersistentVolumeFilesystem, attacherPodFs),
-		Entry("Block volume mode", k8sv1.PersistentVolumeBlock, attacherPodBlock),
+		Entry("Filesystem volume mode", Label("FS"), k8sv1.PersistentVolumeFilesystem, withFileSystem, fsAttachCommand),
+		Entry("Block volume mode", Label("Block"), k8sv1.PersistentVolumeBlock, withBlock, blockAttachCommand),
 	)
 
-	DescribeTable("creates a pvc, attaches to pod, re-attach to another pod", Label("pvcCreation"), func(volumeMode k8sv1.PersistentVolumeMode, podCreationFunc func(string) *k8sv1.Pod) {
+	DescribeTable("creates a pvc, attaches to pod, re-attach to another pod", Label("pvcCreation"), func(volumeMode k8sv1.PersistentVolumeMode, storageOpt storageOption, attachCmd string) {
 		nodes, err := tenantClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		// select at least two node names
@@ -123,23 +127,25 @@ var _ = Describe("CreatePVC", func() {
 		_, err = tenantClient.CoreV1().PersistentVolumeClaims(namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		podSpec := podCreationFunc(pvc.Name)
-		podSpec.Spec.NodeSelector = map[string]string{hostNameLabelKey: host1}
+		podSpec := createPod("test-pod",
+			storageOpt(pvc.Name),
+			withCommand(attachCmd),
+			withNodeSelector(hostNameLabelKey, host1))
 
 		By(fmt.Sprintf("creating a pod that attaches pvc on node %s", host1))
-		pod := runPod(tenantClient.CoreV1(), namespace, podSpec)
+		pod := runPod(tenantClient.CoreV1(), namespace, podSpec, true)
 		deletePod(tenantClient.CoreV1(), namespace, pod.Name)
 
 		pod.Spec.NodeSelector = map[string]string{hostNameLabelKey: host2}
 		By(fmt.Sprintf("creating a pod that attaches pvc on node %s", host2))
-		anotherPod := runPod(tenantClient.CoreV1(), namespace, podSpec)
+		anotherPod := runPod(tenantClient.CoreV1(), namespace, podSpec, true)
 		deletePod(tenantClient.CoreV1(), namespace, anotherPod.Name)
 	},
-		Entry("Filesystem volume mode", k8sv1.PersistentVolumeFilesystem, attacherPodFs),
-		Entry("Block volume mode", k8sv1.PersistentVolumeBlock, attacherPodBlock),
+		Entry("Filesystem volume mode", Label("FS"), k8sv1.PersistentVolumeFilesystem, withFileSystem, fsAttachCommand),
+		Entry("Block volume mode", Label("Block"), k8sv1.PersistentVolumeBlock, withBlock, blockAttachCommand),
 	)
 
-	DescribeTable("verify persistence - creates a pvc, attaches to writer pod, re-attach to a reader pod", Label("pvcCreation"), func(volumeMode k8sv1.PersistentVolumeMode, podWriterFunc func(string) *k8sv1.Pod, podReaderFunc func(string) *k8sv1.Pod) {
+	DescribeTable("verify persistence - creates a pvc, attaches to writer pod, re-attach to a reader pod", Label("pvcCreation"), func(volumeMode k8sv1.PersistentVolumeMode, storageOpt storageOption, writeCmd, readCmd string) {
 		By("creating a pvc")
 		pvc := pvcSpec("test-pvc", "kubevirt", "10Mi")
 		pvc.Spec.VolumeMode = &volumeMode
@@ -147,11 +153,18 @@ var _ = Describe("CreatePVC", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("creating a pod that writes to pvc on node")
-		writerPod := runPod(tenantClient.CoreV1(), namespace, podWriterFunc(pvc.Name))
+		rPod := createPod("writer-pod",
+			withCommand(writeCmd),
+			storageOpt(pvc.Name),
+		)
+		writerPod := runPod(tenantClient.CoreV1(), namespace, rPod, true)
 		deletePod(tenantClient.CoreV1(), namespace, writerPod.Name)
 
 		By("creating a different pod that reads from pvc")
-		readerPod := runPod(tenantClient.CoreV1(), namespace, podReaderFunc(pvc.Name))
+		wPod := createPod("reader-pod",
+			withCommand(readCmd),
+			storageOpt(pvc.Name))
+		readerPod := runPod(tenantClient.CoreV1(), namespace, wPod, true)
 		s := tenantClient.CoreV1().Pods(namespace).GetLogs(readerPod.Name, &k8sv1.PodLogOptions{})
 		reader, err := s.Stream(context.Background())
 		Expect(err).ToNot(HaveOccurred())
@@ -165,11 +178,11 @@ var _ = Describe("CreatePVC", func() {
 		Expect(strings.TrimSpace(out)).To(Equal("testing"))
 		deletePod(tenantClient.CoreV1(), namespace, readerPod.Name)
 	},
-		Entry("Filesystem volume mode", k8sv1.PersistentVolumeFilesystem, writerPodFs, readerPodFs),
-		Entry("Block volume mode", k8sv1.PersistentVolumeBlock, writerPodBlock, readerPodBlock),
+		Entry("Filesystem volume mode", Label("FS"), k8sv1.PersistentVolumeFilesystem, withFileSystem, fsWriteCommand, fsReadCommand),
+		Entry("Block volume mode", Label("Block"), k8sv1.PersistentVolumeBlock, withBlock, blockWriteCommand, blockReadCommand),
 	)
 
-	DescribeTable("multi attach - creates 3 pvcs, attach all 3 to pod, detach all 3 from the pod", Label("pvcCreation"), func(volumeMode k8sv1.PersistentVolumeMode, podCreationFunc func(string) *k8sv1.Pod) {
+	DescribeTable("multi attach - creates 3 pvcs, attach all 3 to pod, detach all 3 from the pod", Label("pvcCreation"), func(volumeMode k8sv1.PersistentVolumeMode, storageOpt storageOption, attachCmd string) {
 		By("creating a pvc")
 		pvc1 := pvcSpec("test-pvc1", "kubevirt", "10Mi")
 		pvc1.Spec.VolumeMode = &volumeMode
@@ -185,18 +198,20 @@ var _ = Describe("CreatePVC", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("creating a pod that uses 3 PVCs")
-		podSpec := podCreationFunc(pvc1.Name)
-		addPvc(podSpec, pvc2.Name, "/pv2")
-		addPvc(podSpec, pvc3.Name, "/pv3")
+		podSpec := createPod("test-pod",
+			withCommand(attachCmd),
+			storageOpt(pvc1.Name),
+			withPVC(pvc2.Name, "/pv2"),
+			withPVC(pvc3.Name, "/pv3"))
 
-		pod := runPod(tenantClient.CoreV1(), namespace, podSpec)
+		pod := runPod(tenantClient.CoreV1(), namespace, podSpec, true)
 		deletePod(tenantClient.CoreV1(), namespace, pod.Name)
 	},
-		Entry("Filesystem volume mode", k8sv1.PersistentVolumeFilesystem, attacherPodFs),
-		Entry("Block volume mode", k8sv1.PersistentVolumeBlock, attacherPodBlock),
+		Entry("Filesystem volume mode", Label("FS"), k8sv1.PersistentVolumeFilesystem, withFileSystem, fsAttachCommand),
+		Entry("Block volume mode", Label("Block"), k8sv1.PersistentVolumeBlock, withBlock, blockAttachCommand),
 	)
 
-	DescribeTable("multi attach - create multiple pods pvcs on same node, and each pod should connect to a different PVC", Label("pvcCreation"), func(volumeMode k8sv1.PersistentVolumeMode, podCreationFunc func(string) *k8sv1.Pod) {
+	DescribeTable("multi attach - create multiple pods pvcs on same node, and each pod should connect to a different PVC", Label("pvcCreation"), func(volumeMode k8sv1.PersistentVolumeMode, storageOpt storageOption, attachCmd string) {
 		nodes, err := tenantClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		host := nodes.Items[0].Labels[hostNameLabelKey]
@@ -215,11 +230,13 @@ var _ = Describe("CreatePVC", func() {
 
 		podList := make([]*k8sv1.Pod, 0)
 		for _, pvc := range pvcList {
-			podSpec := podCreationFunc(pvc.Name)
-			podSpec.Spec.NodeSelector = map[string]string{hostNameLabelKey: host}
+			podSpec := createPod("test-pod",
+				storageOpt(pvc.Name),
+				withCommand(attachCmd),
+				withNodeSelector(hostNameLabelKey, host))
 
 			By(fmt.Sprintf("creating a pod that attaches pvc on node %s", host))
-			pod := runPod(tenantClient.CoreV1(), namespace, podSpec)
+			pod := runPod(tenantClient.CoreV1(), namespace, podSpec, true)
 			podList = append(podList, pod)
 		}
 		Eventually(func() bool {
@@ -240,11 +257,11 @@ var _ = Describe("CreatePVC", func() {
 			deletePod(tenantClient.CoreV1(), namespace, pod.Name)
 		}
 	},
-		Entry("Filesystem volume mode", k8sv1.PersistentVolumeFilesystem, attacherPodFs),
-		Entry("Block volume mode", k8sv1.PersistentVolumeBlock, attacherPodBlock),
+		Entry("Filesystem volume mode", Label("FS"), k8sv1.PersistentVolumeFilesystem, withFileSystem, fsAttachCommand),
+		Entry("Block volume mode", Label("Block"), k8sv1.PersistentVolumeBlock, withBlock, blockAttachCommand),
 	)
 
-	DescribeTable("Verify infra cluster cleanup", Label("pvc cleanup"), func(volumeMode k8sv1.PersistentVolumeMode, podCreationFunc func(string) *k8sv1.Pod) {
+	DescribeTable("Verify infra cluster cleanup", Label("pvc cleanup"), func(volumeMode k8sv1.PersistentVolumeMode, storageOpt storageOption, attachCmd string) {
 		pvcName := "test-pvc"
 		storageClassName := "kubevirt"
 		pvc := pvcSpec(pvcName, storageClassName, "10Mi")
@@ -258,8 +275,11 @@ var _ = Describe("CreatePVC", func() {
 		}, time.Second*30, time.Second).Should(Equal(k8sv1.ClaimBound))
 		volumeName := pvc.Spec.VolumeName
 
-		podSpec := podCreationFunc(pvc.Name)
-		pod := runPod(tenantClient.CoreV1(), namespace, podSpec)
+		podSpec := createPod("test-pod",
+			storageOpt(pvc.Name),
+			withCommand(attachCmd))
+
+		pod := runPod(tenantClient.CoreV1(), namespace, podSpec, true)
 		pod, err = tenantClient.CoreV1().Pods(namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pod.Status.Phase).To(BeElementOf(k8sv1.PodSucceeded, k8sv1.PodRunning))
@@ -283,8 +303,8 @@ var _ = Describe("CreatePVC", func() {
 			return errors.IsNotFound(err)
 		}, 1*time.Minute, 2*time.Second).Should(BeTrue(), "infra pvc should disappear")
 	},
-		Entry("Filesystem volume mode", k8sv1.PersistentVolumeFilesystem, attacherPodFs),
-		Entry("Block volume mode", k8sv1.PersistentVolumeBlock, attacherPodBlock),
+		Entry("Filesystem volume mode", Label("FS"), k8sv1.PersistentVolumeFilesystem, withFileSystem, fsAttachCommand),
+		Entry("Block volume mode", Label("Block"), k8sv1.PersistentVolumeBlock, withBlock, blockAttachCommand),
 	)
 
 	Context("Should prevent access to volumes from infra cluster", func() {
@@ -393,7 +413,8 @@ var _ = Describe("CreatePVC", func() {
 			}
 			tenantPVC, err = tenantClient.CoreV1().PersistentVolumeClaims(namespace).Create(context.Background(), tenantPVC, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			pod := writerPodFs(tenantPVC.Name)
+			pod := createPod("reader-pod", withFileSystem(tenantPVC.Name), withCommand(fsWriteCommand))
+
 			By("Creating pod that attempts to use the specially crafted PVC")
 			pod, err = tenantClient.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -418,174 +439,6 @@ var _ = Describe("CreatePVC", func() {
 	})
 })
 
-func writerPodFs(volumeName string) *k8sv1.Pod {
-	return podWithFilesystemPvcSpec("writer-pod",
-		volumeName,
-		[]string{"sh"},
-		[]string{"-c", "echo testing > /opt/test.txt"})
-}
-
-func readerPodFs(pvcName string) *k8sv1.Pod {
-	return podWithFilesystemPvcSpec("reader-pod",
-		pvcName,
-		[]string{"sh"},
-		[]string{"-c", "cat /opt/test.txt"})
-}
-
-func writerPodBlock(volumeName string) *k8sv1.Pod {
-	return podWithBlockPvcSpec("writer-pod",
-		volumeName,
-		[]string{"sh"},
-		[]string{"-c", "echo testing > /dev/csi"})
-}
-
-func readerPodBlock(pvcName string) *k8sv1.Pod {
-	return podWithBlockPvcSpec("reader-pod",
-		pvcName,
-		[]string{"sh"},
-		[]string{"-c", "head -c 8 /dev/csi"})
-}
-
-func attacherPodFs(pvcName string) *k8sv1.Pod {
-	return podWithFilesystemPvcSpec("test-pod",
-		pvcName,
-		[]string{"sh"},
-		[]string{"-c", "ls -la /opt && echo kubevirt-csi-driver && mktemp /opt/test-XXXXXX"})
-}
-
-func attacherPodBlock(pvcName string) *k8sv1.Pod {
-	return podWithBlockPvcSpec("test-pod",
-		pvcName,
-		[]string{"sh"},
-		[]string{"-c", "ls -al /dev/csi"})
-}
-
-func podWithoutPVCSpec(podName string, cmd, args []string) *k8sv1.Pod {
-	image := "busybox"
-	return &k8sv1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: podName,
-		},
-		Spec: k8sv1.PodSpec{
-			SecurityContext: &k8sv1.PodSecurityContext{
-				SeccompProfile: &k8sv1.SeccompProfile{
-					Type: k8sv1.SeccompProfileTypeRuntimeDefault,
-				},
-			},
-			RestartPolicy: k8sv1.RestartPolicyNever,
-			Containers: []k8sv1.Container{
-				{
-					SecurityContext: &k8sv1.SecurityContext{
-						Capabilities: &k8sv1.Capabilities{
-							Drop: []k8sv1.Capability{
-								"ALL",
-							},
-						},
-					},
-					Name:    podName,
-					Image:   image,
-					Command: cmd,
-					Args:    args,
-				},
-			},
-			// add toleration so we can use control node for tests
-			Tolerations: []k8sv1.Toleration{
-				{
-					Key:      "node-role.kubernetes.io/master",
-					Operator: k8sv1.TolerationOpExists,
-					Effect:   k8sv1.TaintEffectNoSchedule,
-				},
-				{
-					Key:      "node-role.kubernetes.io/control-plane",
-					Operator: k8sv1.TolerationOpExists,
-					Effect:   k8sv1.TaintEffectNoSchedule,
-				},
-			},
-		},
-	}
-}
-
-func podWithBlockPvcSpec(podName, pvcName string, cmd, args []string) *k8sv1.Pod {
-	podSpec := podWithoutPVCSpec(podName, cmd, args)
-	volumeName := "blockpv"
-	podSpec.Spec.Volumes = append(podSpec.Spec.Volumes, k8sv1.Volume{
-		Name: volumeName,
-		VolumeSource: k8sv1.VolumeSource{
-			PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-				ClaimName: pvcName,
-			},
-		},
-	})
-	podSpec.Spec.Containers[0].VolumeDevices = []k8sv1.VolumeDevice{
-		{
-			Name:       volumeName,
-			DevicePath: "/dev/csi",
-		},
-	}
-	return podSpec
-}
-
-func podWithFilesystemPvcSpec(podName, pvcName string, cmd, args []string) *k8sv1.Pod {
-	podSpec := podWithoutPVCSpec(podName, cmd, args)
-	volumeName := "fspv"
-	podSpec.Spec.Volumes = append(podSpec.Spec.Volumes, k8sv1.Volume{
-		Name: volumeName,
-		VolumeSource: k8sv1.VolumeSource{
-			PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-				ClaimName: pvcName,
-			},
-		},
-	})
-	podSpec.Spec.Containers[0].VolumeMounts = []k8sv1.VolumeMount{
-		{
-			Name:      volumeName,
-			MountPath: "/opt",
-		},
-	}
-	return podSpec
-}
-
-func addPvc(podSpec *k8sv1.Pod, pvcName string, mountPath string) *k8sv1.Pod {
-	volumeName := pvcName
-	podSpec.Spec.Volumes = append(
-		podSpec.Spec.Volumes,
-		k8sv1.Volume{
-			Name: volumeName,
-			VolumeSource: k8sv1.VolumeSource{
-				PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-					ClaimName: pvcName,
-				},
-			},
-		})
-	if len(podSpec.Spec.Containers[0].VolumeMounts) > 0 {
-		podSpec = addVolumeMount(podSpec, volumeName, mountPath)
-	}
-	if len(podSpec.Spec.Containers[0].VolumeDevices) > 0 {
-		podSpec = addVolumeDevice(podSpec, volumeName)
-	}
-	return podSpec
-}
-
-func addVolumeMount(podSpec *k8sv1.Pod, volumeName string, mountPath string) *k8sv1.Pod {
-	podSpec.Spec.Containers[0].VolumeMounts = append(
-		podSpec.Spec.Containers[0].VolumeMounts,
-		k8sv1.VolumeMount{
-			Name:      volumeName,
-			MountPath: mountPath,
-		})
-	return podSpec
-}
-
-func addVolumeDevice(podSpec *k8sv1.Pod, volumeName string) *k8sv1.Pod {
-	podSpec.Spec.Containers[0].VolumeDevices = append(
-		podSpec.Spec.Containers[0].VolumeDevices,
-		k8sv1.VolumeDevice{
-			Name:       volumeName,
-			DevicePath: fmt.Sprintf("/dev/%s", volumeName),
-		})
-	return podSpec
-}
-
 func pvcSpec(pvcName, storageClassName, size string) *k8sv1.PersistentVolumeClaim {
 	quantity, err := resource.ParseQuantity(size)
 	Expect(err).ToNot(HaveOccurred())
@@ -606,23 +459,21 @@ func pvcSpec(pvcName, storageClassName, size string) *k8sv1.PersistentVolumeClai
 	return pvc
 }
 
-func runPod(client v1.CoreV1Interface, namespace string, pod *k8sv1.Pod) *k8sv1.Pod {
+func runPod(client v1.CoreV1Interface, namespace string, pod *k8sv1.Pod, waitComplete bool) *k8sv1.Pod {
 	pod, err := client.Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
+	expectedPhase := k8sv1.PodSucceeded
+	if !waitComplete {
+		expectedPhase = k8sv1.PodRunning
+	}
 	By("Wait for pod to reach a completed phase")
-	Eventually(func() error {
+	Eventually(func(g Gomega) k8sv1.PodPhase {
 		pod, err = client.Pods(namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		// TODO: change command and wait for completed/succeeded
-		if pod.Status.Phase != k8sv1.PodSucceeded {
-			return fmt.Errorf("Pod in phase %s, expected Succeeded", pod.Status.Phase)
-		}
+		g.Expect(err).ToNot(HaveOccurred())
+		return pod.Status.Phase
+	}, 3*time.Minute, 5*time.Second).Should(Equal(expectedPhase), "Pod should reach Succeeded state")
 
-		return nil
-	}, 3*time.Minute, 5*time.Second).Should(Succeed(), "Pod should reach Succeeded state")
 	//Ensure we don't see couldn't find device by serial id in pod event log.
 	events, err := client.Events(namespace).List(context.Background(), metav1.ListOptions{FieldSelector: fmt.Sprintf("involvedObject.name=%s", pod.Name), TypeMeta: metav1.TypeMeta{Kind: "Pod"}})
 	Expect(err).ToNot(HaveOccurred())

--- a/e2e/create_pod_helper_test.go
+++ b/e2e/create_pod_helper_test.go
@@ -1,0 +1,187 @@
+package e2e_test
+
+import (
+	"fmt"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	fsCommonFile    = "/opt/test.txt"
+	fsWriteCommand  = "echo testing > " + fsCommonFile
+	fsReadCommand   = "cat " + fsCommonFile
+	fsAttachCommand = "ls -la /opt && echo kubevirt-csi-driver && mktemp /opt/test-XXXXXX"
+
+	blockCommonFile    = "/dev/csi"
+	blockWriteCommand  = "echo testing > " + blockCommonFile
+	blockReadCommand   = "head -c 8 " + blockCommonFile
+	blockAttachCommand = "ls -al /dev/csi"
+)
+
+type podOption func(pod *k8sv1.Pod)
+type storageOption func(string) podOption
+
+func createPod(podName string, opts ...podOption) *k8sv1.Pod {
+	pod := &k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: podName,
+		},
+		Spec: k8sv1.PodSpec{
+			SecurityContext: &k8sv1.PodSecurityContext{
+				SeccompProfile: &k8sv1.SeccompProfile{
+					Type: k8sv1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			RestartPolicy: k8sv1.RestartPolicyNever,
+			Containers: []k8sv1.Container{
+				{
+					SecurityContext: &k8sv1.SecurityContext{
+						Capabilities: &k8sv1.Capabilities{
+							Drop: []k8sv1.Capability{
+								"ALL",
+							},
+						},
+					},
+					Name:  podName,
+					Image: "busybox",
+				},
+			},
+			// add toleration so we can use control node for tests
+			Tolerations: []k8sv1.Toleration{
+				{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: k8sv1.TolerationOpExists,
+					Effect:   k8sv1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "node-role.kubernetes.io/control-plane",
+					Operator: k8sv1.TolerationOpExists,
+					Effect:   k8sv1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+
+	for _, o := range opts {
+		o(pod)
+	}
+
+	return pod
+}
+
+func withCommand(cmd string) podOption {
+	return func(pod *k8sv1.Pod) {
+		pod.Spec.Containers[0].Command = []string{"sh"}
+		pod.Spec.Containers[0].Args = []string{"-c", cmd}
+	}
+}
+
+func withBlock(pvcName string) podOption {
+	const volumeName = "blockpv"
+	return func(pod *k8sv1.Pod) {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, getVolume(volumeName, pvcName))
+		pod.Spec.Containers[0].VolumeDevices = []k8sv1.VolumeDevice{
+			{
+				Name:       volumeName,
+				DevicePath: "/dev/csi",
+			},
+		}
+	}
+}
+
+func withFileSystem(pvcName string) podOption {
+	const volumeName = "fspv"
+	return func(pod *k8sv1.Pod) {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, getVolume(volumeName, pvcName))
+		pod.Spec.Containers[0].VolumeMounts = []k8sv1.VolumeMount{
+			{
+				Name:      volumeName,
+				MountPath: "/opt",
+			},
+		}
+	}
+}
+
+func withNodeSelector(key, value string) podOption {
+	return func(pod *k8sv1.Pod) {
+		if pod.Spec.NodeSelector == nil {
+			pod.Spec.NodeSelector = make(map[string]string)
+		}
+		pod.Spec.NodeSelector[key] = value
+	}
+}
+
+func withLabel(key, value string) podOption {
+	return func(pod *k8sv1.Pod) {
+		if pod.Labels == nil {
+			pod.Labels = make(map[string]string)
+		}
+		pod.Labels[key] = value
+	}
+}
+
+func withPodAntiAffinity(key, value string) podOption {
+	return func(pod *k8sv1.Pod) {
+		pod.Spec.Affinity = &k8sv1.Affinity{
+			PodAntiAffinity: &k8sv1.PodAntiAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      key,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{value},
+								},
+							},
+						},
+						TopologyKey: hostNameLabelKey,
+					},
+				},
+			},
+		}
+	}
+}
+
+func getVolume(volumeName, pvcName string) k8sv1.Volume {
+	return k8sv1.Volume{
+		Name: volumeName,
+		VolumeSource: k8sv1.VolumeSource{
+			PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvcName,
+			},
+		},
+	}
+}
+
+func withPVC(pvcName string, mountPath string) podOption {
+	return func(pod *k8sv1.Pod) {
+		pod.Spec.Volumes = append(pod.Spec.Volumes, getVolume(pvcName, pvcName))
+		if len(pod.Spec.Containers[0].VolumeMounts) > 0 {
+			addVolumeMount(pod, pvcName, mountPath)
+		}
+		if len(pod.Spec.Containers[0].VolumeDevices) > 0 {
+			addVolumeDevice(pod, pvcName)
+		}
+
+	}
+}
+
+func addVolumeMount(podSpec *k8sv1.Pod, volumeName string, mountPath string) {
+	podSpec.Spec.Containers[0].VolumeMounts = append(
+		podSpec.Spec.Containers[0].VolumeMounts,
+		k8sv1.VolumeMount{
+			Name:      volumeName,
+			MountPath: mountPath,
+		})
+}
+
+func addVolumeDevice(podSpec *k8sv1.Pod, volumeName string) {
+	podSpec.Spec.Containers[0].VolumeDevices = append(
+		podSpec.Spec.Containers[0].VolumeDevices,
+		k8sv1.VolumeDevice{
+			Name:       volumeName,
+			DevicePath: fmt.Sprintf("/dev/%s", volumeName),
+		})
+}

--- a/hack/cluster-sync-split.sh
+++ b/hack/cluster-sync-split.sh
@@ -101,5 +101,8 @@ _kubectl apply --kustomize ./deploy/controller-infra/dev-overlay
 # ******************************************************
 # Wait for driver to rollout
 # ******************************************************
+_kubectl_tenant rollout restart ds/kubevirt-csi-node -n $CSI_DRIVER_NAMESPACE
+_kubectl rollout restart deployment/kubevirt-csi-controller -n $TENANT_CLUSTER_NAMESPACE
+
 _kubectl_tenant rollout status ds/kubevirt-csi-node -n $CSI_DRIVER_NAMESPACE --timeout=10m
 _kubectl rollout status deployment/kubevirt-csi-controller -n $TENANT_CLUSTER_NAMESPACE --timeout=10m

--- a/hack/cluster-up.sh
+++ b/hack/cluster-up.sh
@@ -16,7 +16,7 @@ echo "Creating $TENANT_CLUSTER_NAMESPACE"
 ./kubevirtci create-cluster
 
 echo "Waiting for $TENANT_CLUSTER_NAMESPACE vmis to be ready"
-./kubevirtci kubectl wait --for=condition=Ready vmi -l capk.cluster.x-k8s.io/kubevirt-machine-namespace=$TENANT_CLUSTER_NAMESPACE -n $TENANT_CLUSTER_NAMESPACE
+./kubevirtci kubectl wait --for=condition=Ready vmi -l capk.cluster.x-k8s.io/kubevirt-machine-namespace=$TENANT_CLUSTER_NAMESPACE -n $TENANT_CLUSTER_NAMESPACE --timeout=300s
 
 echo "Installing networking (calico)"
 ./kubevirtci install-calico

--- a/hack/generate_clients.sh
+++ b/hack/generate_clients.sh
@@ -4,7 +4,6 @@ set -o nounset
 set -o pipefail
 
 go install k8s.io/code-generator/cmd/client-gen@latest
-go get kubevirt.io/api
 client-gen --input-base="kubevirt.io/api/" --input="core/v1" --output-package="kubevirt.io/csi-driver/pkg/generated/kubevirt/client-go/clientset" --output-base="../../" --clientset-name="versioned" --go-header-file hack/boilerplate.go.txt
 
 go get kubevirt.io/containerized-data-importer-api

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -30,8 +30,24 @@ if [ ! -f "${KUBECTL_PATH}" ]; then
         curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o ${KUBECTL_PATH}
         chmod u+x ${KUBECTL_PATH}
 fi
-        
+
+GINKGO_LABELS=""
+if [[ -n ${LABELS} ]]; then
+  GINKGO_LABELS="--ginkgo.label-filter=${LABELS}"
+fi
+
 rm -rf $TEST_WORKING_DIR
 mkdir -p $TEST_WORKING_DIR
 
-$BIN_DIR/e2e.test -ginkgo.v -test.v -ginkgo.no-color --kubectl-path $KUBECTL_PATH --clusterctl-path $CLUSTERCTL_PATH  --virtctl-path $VIRTCTL_PATH --working-dir $TEST_WORKING_DIR --dump-path $DUMP_PATH --infra-kubeconfig=$KUBECONFIG --infra-cluster-namespace=${INFRA_CLUSTER_NAMESPACE}
+$BIN_DIR/e2e.test \
+  -ginkgo.v \
+  -test.v \
+  -ginkgo.no-color \
+  --kubectl-path "${KUBECTL_PATH}" \
+  --clusterctl-path "${CLUSTERCTL_PATH}"  \
+  --virtctl-path "${VIRTCTL_PATH}" \
+  --working-dir "${TEST_WORKING_DIR}" \
+  --dump-path "${DUMP_PATH}" \
+  --infra-kubeconfig="${KUBECONFIG}" \
+  --infra-cluster-namespace="${INFRA_CLUSTER_NAMESPACE}" \
+  ${GINKGO_LABELS}

--- a/hack/test-driver-rwx.yaml
+++ b/hack/test-driver-rwx.yaml
@@ -17,10 +17,9 @@ DriverInfo:
     snapshotDataSource: true
     topology: false
     capacity: false
-    RWX: false
-  SupportedFsType:
-    ext4: {}
-    xfs: {}
+    RWX: true
+  RequiredAccessModes:
+  - ReadWriteMany
 InlineVolumes:
 - shared: false
 


### PR DESCRIPTION
**What this PR does / why we need it**:
For CreateVolume requests with access mode of ReadWriteMany and volume mode of Block, the driver now creates underline PVC with the same ReadWriteMany access mode, and block volume mode.

The driver now rejects CreateVolume requests with access mode of ReadWriteMany and volume mode of volume mode of fileSystem.
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support Read Write Many (RWX)
```

