### PR TITLE
Address CVE-2024-1725

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,11 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 # You can list all codegen related variables by:
 #   $ make -n --print-data-base | grep ^CODEGEN
 .PHONY: image-build
-image-build: generate
+# let's disable generate for for now
+# it updates libs and I think it is better to do that manually
+# especially when changes will be backported
+#image-build: generate
+image-build:
 	source ./hack/cri-bin.sh && \
 	$$CRI_BIN build -t $(IMAGE_REF) --build-arg git_sha=$(SHA) .
 

--- a/e2e/common_test.go
+++ b/e2e/common_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
+	cdicli "kubevirt.io/csi-driver/pkg/generated/containerized-data-importer/client-go/clientset/versioned"
 )
 
 // RunCmd function executes a command, and returns STDOUT and STDERR bytes
@@ -190,6 +191,15 @@ func generateInfraClient() (*kubernetes.Clientset, error) {
 	}
 
 	return kubernetes.NewForConfig(restConfig)
+}
+
+func generateInfraCdiClient() (*cdicli.Clientset, error) {
+	restConfig, err := generateInfraRestConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return cdicli.NewForConfig(restConfig)
 }
 
 func generateInfraSnapClient() (*snapcli.Clientset, error) {

--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -8,6 +8,7 @@ INFRA_STORAGE_CLASS=${INFRA_STORAGE_CLASS:-rook-ceph-block}
 REGISTRY=${REGISTRY:-192.168.66.2:5000}
 TARGET_NAME=${TARGET_NAME:-kubevirt-csi-driver}
 TAG=${TAG:-latest}
+export INFRACLUSTER_LABELS=${INFRACLUSTER_LABELS:-"tenant-cluster=${TENANT_CLUSTER_NAMESPACE}"}
 
 function tenant::deploy_kubeconfig_secret() {
   TOKEN=$(_kubectl create token kubevirt-csi -n $TENANT_CLUSTER_NAMESPACE)

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -256,6 +256,11 @@ func (c *ControllerService) ControllerPublishVolume(
 		return nil, err
 	}
 	dvName := req.GetVolumeId()
+	if _, err := c.virtClient.GetDataVolume(ctx, c.infraClusterNamespace, dvName); errors.IsNotFound(err) {
+		return nil, status.Errorf(codes.NotFound, "volume %s not found", req.GetVolumeId())
+	} else if err != nil {
+		return nil, err
+	}
 
 	klog.V(3).Infof("Attaching DataVolume %s to Node ID %s", dvName, req.NodeId)
 


### PR DESCRIPTION
Restrict access to infrastructure PVCs by requiring matching infraClusterLabels on tenant PVCs

The CVE describes how an attacker may create a PV/PVC in a guest cluster to access any PVC in the infra cluster namespace. The infra cluster PVCs may belong to other guest clusters or have been created out of band from the kubevirt-csi driver.

This PR addresses the issue by:

1.  infraClusterLabels are required (but is up to admin to make sure they are unique per tenant)
2.  guest may only access infra PVCs with matching labels
3.  guest can only access PVCs with specific prefix (default is "pvc-")

Shoutout to @awels who actually implemented this based on input from @davidvossel.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://access.redhat.com/security/cve/CVE-2024-1725

https://bugzilla.redhat.com/show_bug.cgi?id=2265398

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Address CVE-2024-1725 - PV allows access to HCP's root node
```

