### PR TITLE
Get storage class from PVC for snapshot matching

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -141,9 +141,6 @@ kind: ClusterRole
 metadata:
   name: kubevirt-csi-snapshot
 rules:
-- apiGroups: [""]
-  resources: ["persistentvolumes"]
-  verbs: ["get"]
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["get"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Instead of using the PV to get the storage class use the PVC storage class instead. If it is nil then k8s version is < 1.28 and we return an error indicating we cannot determine the storage class name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

