### PR TITLE
Lazy load volume/snapshot mapping

### DIFF
--- a/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+++ b/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
@@ -97,6 +97,7 @@ func handle() {
 	}
 
 	infraClusterLabelsMap := parseLabels()
+	klog.V(5).Infof("Storage class enforcement string: \n%s", infraStorageClassEnforcement)
 	storageClassEnforcement := configureStorageClassEnforcement(infraStorageClassEnforcement)
 
 	virtClient, err := kubevirt.NewClient(infraRestConfig, infraClusterLabelsMap, tenantClientSet, tenantSnapshotClientSet, storageClassEnforcement, *volumePrefix)

--- a/hack/generate_clients.sh
+++ b/hack/generate_clients.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-go install k8s.io/code-generator/cmd/client-gen@latest
+go install k8s.io/code-generator/cmd/client-gen@v0.28.6
 client-gen --input-base="kubevirt.io/api/" --input="core/v1" --output-package="kubevirt.io/csi-driver/pkg/generated/kubevirt/client-go/clientset" --output-base="../../" --clientset-name="versioned" --go-header-file hack/boilerplate.go.txt
 
 go get kubevirt.io/containerized-data-importer-api

--- a/pkg/kubevirt/client_test.go
+++ b/pkg/kubevirt/client_test.go
@@ -135,8 +135,7 @@ var _ = Describe("Client", func() {
 
 		DescribeTable("should return snapshot class from claim or error", func(claimName, namespace, snapshotClassName, resultSnapshotClassName string, expectedError bool) {
 			c.storageClassEnforcement = createDefaultStorageClassEnforcement()
-			fakeTenantSnapClient := snapfake.NewSimpleClientset()
-			mapping, err := c.buildStorageClassSnapshotClassMapping(c.tenantKubernetesClient, fakeTenantSnapClient, c.storageClassEnforcement.StorageSnapshotMapping)
+			mapping, err := c.buildStorageClassSnapshotClassMapping(c.tenantSnapClient, c.storageClassEnforcement.StorageSnapshotMapping)
 			Expect(err).ToNot(HaveOccurred())
 			c.infraTenantStorageSnapshotMapping = mapping
 			res, err := c.getSnapshotClassNameFromVolumeClaimName(context.TODO(), namespace, claimName, snapshotClassName)
@@ -206,8 +205,7 @@ var _ = Describe("Client", func() {
 
 		It("should delete volumesnapshot if it exists and it valid", func() {
 			c.storageClassEnforcement = createDefaultStorageClassEnforcement()
-			fakeTenantSnapClient := snapfake.NewSimpleClientset()
-			mapping, err := c.buildStorageClassSnapshotClassMapping(c.tenantKubernetesClient, fakeTenantSnapClient, c.storageClassEnforcement.StorageSnapshotMapping)
+			mapping, err := c.buildStorageClassSnapshotClassMapping(c.tenantSnapClient, c.storageClassEnforcement.StorageSnapshotMapping)
 			Expect(err).ToNot(HaveOccurred())
 			c.infraTenantStorageSnapshotMapping = mapping
 			s, err := c.CreateVolumeSnapshot(context.TODO(), testNamespace, "snap", validDataVolume, volumeSnapshotClassName)
@@ -224,8 +222,7 @@ var _ = Describe("Client", func() {
 
 		It("should return error if get volume returns an error", func() {
 			c.storageClassEnforcement = createDefaultStorageClassEnforcement()
-			fakeTenantSnapClient := snapfake.NewSimpleClientset()
-			mapping, err := c.buildStorageClassSnapshotClassMapping(c.tenantKubernetesClient, fakeTenantSnapClient, c.storageClassEnforcement.StorageSnapshotMapping)
+			mapping, err := c.buildStorageClassSnapshotClassMapping(c.tenantSnapClient, c.storageClassEnforcement.StorageSnapshotMapping)
 			Expect(err).ToNot(HaveOccurred())
 			c.infraTenantStorageSnapshotMapping = mapping
 			s, err := c.CreateVolumeSnapshot(context.TODO(), testNamespace, "snap", validDataVolume, volumeSnapshotClassName)
@@ -238,8 +235,7 @@ var _ = Describe("Client", func() {
 
 		It("should properly list snapshots", func() {
 			c.storageClassEnforcement = createDefaultStorageClassEnforcement()
-			fakeTenantSnapClient := snapfake.NewSimpleClientset()
-			mapping, err := c.buildStorageClassSnapshotClassMapping(c.tenantKubernetesClient, fakeTenantSnapClient, c.storageClassEnforcement.StorageSnapshotMapping)
+			mapping, err := c.buildStorageClassSnapshotClassMapping(c.tenantSnapClient, c.storageClassEnforcement.StorageSnapshotMapping)
 			Expect(err).ToNot(HaveOccurred())
 			c.infraTenantStorageSnapshotMapping = mapping
 			s, err := c.CreateVolumeSnapshot(context.TODO(), testNamespace, "snap", validDataVolume, volumeSnapshotClassName)
@@ -264,7 +260,8 @@ var _ = Describe("Client", func() {
 
 		DescribeTable("should properly determine snapshot class from storage class", func(snapshotClassName, claimName string, enforcement util.StorageClassEnforcement, tenantSnapClient snapcli.Interface, expected, expectedError string) {
 			c.storageClassEnforcement = enforcement
-			mapping, err := c.buildStorageClassSnapshotClassMapping(c.tenantKubernetesClient, tenantSnapClient, c.storageClassEnforcement.StorageSnapshotMapping)
+			c.tenantSnapClient = tenantSnapClient
+			mapping, err := c.buildStorageClassSnapshotClassMapping(tenantSnapClient, c.storageClassEnforcement.StorageSnapshotMapping)
 			Expect(err).ToNot(HaveOccurred())
 			c.infraTenantStorageSnapshotMapping = mapping
 			res, err := c.getSnapshotClassNameFromVolumeClaimName(context.TODO(), testNamespace, claimName, snapshotClassName)
@@ -353,6 +350,7 @@ func NewFakeClient() *client {
 		infraKubernetesClient:  fakeK8sClient,
 		tenantKubernetesClient: fakeTenantK8sClient,
 		infraSnapClient:        fakeSnapClient,
+		tenantSnapClient:       snapfake.NewSimpleClientset(),
 		infraLabelMap:          map[string]string{"test": "test"},
 		volumePrefix:           "pvc-",
 		storageClassEnforcement: util.StorageClassEnforcement{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Instead of eagerly calculating the mapping do it lazily when the mapping is requested. This will allow the driver to start when the RBAC in the tenant cluster might not be complete yet. Also added some debugging to allow one to determine why a mapping cannot be found easier.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Lazy load storage class/snapshot class mapping between infra and tenant clusters.
```

