### PR TITLE
Fix default snapshot class allowed not working

### DIFF
--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -323,7 +323,11 @@ func (c *client) getSnapshotClassNameFromVolumeClaimName(ctx context.Context, na
 		klog.V(2).Infof("Error getting storage class name for claim %s in namespace %s: %v", claimName, namespace, err)
 		return "", fmt.Errorf("unable to determine volume snapshot class name for infra source volume")
 	}
-	if storageClassName == "" && !c.storageClassEnforcement.AllowDefault {
+	if c.storageClassEnforcement.AllowDefault {
+		// Allow default is set to true, return blank snapshot class name so it remains blank in the created volume snapshot in the infra cluster.
+		return "", nil
+	}
+	if storageClassName == "" {
 		return "", fmt.Errorf("unable to determine volume snapshot class name for snapshot creation, and default not allowed")
 	} else if storageClassName != "" && !(util.Contains(c.storageClassEnforcement.AllowList, storageClassName) || c.storageClassEnforcement.AllowAll) {
 		return "", fmt.Errorf("unable to determine volume snapshot class name for snapshot creation, no valid snapshot classes found based on storage class [%s]", storageClassName)

--- a/pkg/kubevirt/client_test.go
+++ b/pkg/kubevirt/client_test.go
@@ -152,10 +152,18 @@ var _ = Describe("Client", func() {
 		)
 
 		It("should return error if the storage class is not allowed", func() {
+			c.storageClassEnforcement = createDefaultStorageClassEnforcement()
 			res, err := c.getSnapshotClassNameFromVolumeClaimName(context.TODO(), testNamespace, testClaimNameNotAllowed, volumeSnapshotClassName)
 			Expect(err).To(HaveOccurred())
 			Expect(res).To(Equal(""))
 			Expect(err.Error()).To(ContainSubstring(snapshotClassNotFound))
+		})
+
+		It("should return blank without error if default is allowed", func() {
+			c.storageClassEnforcement = createAllowDefaultStorageClassEnforcement()
+			res, err := c.getSnapshotClassNameFromVolumeClaimName(context.TODO(), testNamespace, testClaimNameNotAllowed, volumeSnapshotClassName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(""))
 		})
 
 		It("should return not error if the storage class is not allowed, but allowAll is true", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix bug where if no mapping exists but default is set to allowed, it would reject snapshot requests because it could not find the mapping in the tenant volume snapshot class. This fix will return a blank mapping which then leaves the volume snapshot class for the infra empty relying on the default being set in the infra cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

