### PR TITLE
Support Zone-Aware Topologies in the KubeVirt CSI Driver

### DIFF
--- a/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+++ b/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
@@ -105,7 +105,11 @@ func handle() {
 		klog.Fatal(err)
 	}
 
-	var nodeID string
+	var (
+		nodeID            string
+		allowedTopologies = map[string]string{}
+	)
+
 	if *nodeName != "" {
 		node, err := tenantClientSet.CoreV1().Nodes().Get(context.TODO(), *nodeName, v1.GetOptions{})
 		if err != nil {
@@ -121,6 +125,11 @@ func handle() {
 		}
 		nodeID = fmt.Sprintf("%s/%s", vmNamespace, vmName)
 		klog.Infof("Node name: %v, Node ID: %s", *nodeName, nodeID)
+		// systemUUID is the VM ID
+		nodeID = node.Status.NodeInfo.SystemUUID
+		allowedTopologies[service.WellKnownZoneTopologyKey] = node.Labels[service.WellKnownZoneTopologyKey]
+		allowedTopologies[service.WellKnownRegionTopologyKey] = node.Labels[service.WellKnownRegionTopologyKey]
+		klog.Infof("Node name: %v, Node ID: %s", nodeName, nodeID)
 	}
 
 	identityClientset = tenantClientSet
@@ -138,7 +147,8 @@ func handle() {
 		storageClassEnforcement,
 		nodeID,
 		*runNodeService,
-		*runControllerService)
+		*runControllerService,
+		allowedTopologies)
 
 	driver.Run(*endpoint)
 }

--- a/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+++ b/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
@@ -126,7 +126,7 @@ func handle() {
 		nodeID = fmt.Sprintf("%s/%s", vmNamespace, vmName)
 		klog.Infof("Node name: %v, Node ID: %s", *nodeName, nodeID)
 		// systemUUID is the VM ID
-		nodeID = node.Status.NodeInfo.SystemUUID
+		//nodeID = node.Status.NodeInfo.SystemUUID
 		allowedTopologies[service.WellKnownZoneTopologyKey] = node.Labels[service.WellKnownZoneTopologyKey]
 		allowedTopologies[service.WellKnownRegionTopologyKey] = node.Labels[service.WellKnownRegionTopologyKey]
 		klog.Infof("Node name: %v, Node ID: %s", nodeName, nodeID)

--- a/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+++ b/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
@@ -125,8 +125,6 @@ func handle() {
 		}
 		nodeID = fmt.Sprintf("%s/%s", vmNamespace, vmName)
 		klog.Infof("Node name: %v, Node ID: %s", *nodeName, nodeID)
-		// systemUUID is the VM ID
-		//nodeID = node.Status.NodeInfo.SystemUUID
 		allowedTopologies[service.WellKnownZoneTopologyKey] = node.Labels[service.WellKnownZoneTopologyKey]
 		allowedTopologies[service.WellKnownRegionTopologyKey] = node.Labels[service.WellKnownRegionTopologyKey]
 		klog.Infof("Node name: %v, Node ID: %s", nodeName, nodeID)

--- a/deploy/controller-infra/base/deploy.yaml
+++ b/deploy/controller-infra/base/deploy.yaml
@@ -83,6 +83,7 @@ spec:
             - "--v=5"
             - "--timeout=3m"
             - "--retry-interval-max=1m"
+            - "--feature-gates=Topology=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/controller-tenant/base/deploy.yaml
+++ b/deploy/controller-tenant/base/deploy.yaml
@@ -82,6 +82,7 @@ spec:
             - "--v=5"
             - "--timeout=3m"
             - "--retry-interval-max=1m"
+            - "--feature-gates=Topology=true"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -48,6 +48,12 @@ data:
 END
 }
 
+function tenant::label_all_nodes_with_allowed_topologies() {
+  for node in $(_kubectl get nodes -o name); do
+    _kubectl label $node topology.kubernetes.io/region=eu-central topology.kubernetes.io/zone=az-1 --overwrite
+  done
+}
+
 function cluster::generate_tenant_controller_overlay() {
   cat <<- END > ./deploy/controller-tenant/dev-overlay/controller.yaml
 kind: Deployment
@@ -102,6 +108,7 @@ _kubectl -n $TENANT_CLUSTER_NAMESPACE apply -f ./deploy/infra-cluster-service-ac
 # Generate kustomize overlay for development environment
 # ******************************************************
 tenant::deploy_kubeconfig_secret
+tenant::label_all_nodes_with_allowed_topologies
 cluster::generate_driver_configmap_overlay "tenant"
 cluster::generate_tenant_controller_overlay
 cluster::generate_node_overlay

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -80,6 +80,14 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: csi.kubevirt.io
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.kubernetes.io/zone
+    values:
+    - az-1
+  - key: topology.kubernetes.io/region
+    values:
+    - eu-central
 allowVolumeExpansion: true
 parameters:
   infraStorageClassName: $2

--- a/hack/test-driver-rwx.yaml
+++ b/hack/test-driver-rwx.yaml
@@ -5,6 +5,7 @@ SnapshotClass:
   FromName: true
 DriverInfo:
   Name: csi.kubevirt.io
+  TopologyKeys: ["topology.kubernetes.io/region", "topology.kubernetes.io/zone"]
   Capabilities:
     block: true
     controllerExpansion: true
@@ -18,7 +19,7 @@ DriverInfo:
     persistence: true
     singleNodeVolume: false
     snapshotDataSource: true
-    topology: false
+    topology: true
     capacity: false
     RWX: true
   RequiredAccessModes:

--- a/hack/test-driver.yaml
+++ b/hack/test-driver.yaml
@@ -5,6 +5,7 @@ SnapshotClass:
   FromName: true
 DriverInfo:
   Name: csi.kubevirt.io
+  TopologyKeys: ["topology.kubernetes.io/region", "topology.kubernetes.io/zone"]
   Capabilities:
     block: true
     controllerExpansion: true

--- a/hack/test-driver.yaml
+++ b/hack/test-driver.yaml
@@ -19,7 +19,7 @@ DriverInfo:
     singleNodeVolume: false
     snapshotDataSource: true
     pvcDataSource: true
-    topology: false
+    topology: true
     capacity: false
     RWX: false
   SupportedFsType:

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -1,9 +1,7 @@
 package service
 
 import (
-	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -855,24 +853,6 @@ func (c *ControllerService) ControllerGetCapabilities(context.Context, *csi.Cont
 // ControllerGetVolume unimplemented
 func (c *ControllerService) ControllerGetVolume(_ context.Context, _ *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "")
-}
-
-// getVMNameByCSINodeID finds a VM in infra cluster by its firmware uuid. The uid is the ID that the CSI
-// node publishes in NodeGetInfo and then used by CSINode.spec.drivers[].nodeID
-func (c *ControllerService) getVMNameByCSINodeID(ctx context.Context, nodeID string) (string, error) {
-	list, err := c.virtClient.ListVirtualMachines(ctx, c.infraClusterNamespace)
-	if err != nil {
-		klog.Error("failed listing VMIs in infra cluster")
-		return "", status.Error(codes.NotFound, fmt.Sprintf("failed listing VMIs in infra cluster %v", err))
-	}
-
-	for _, vmi := range list {
-		if strings.EqualFold(string(vmi.Spec.Domain.Firmware.UUID), nodeID) {
-			return vmi.Name, nil
-		}
-	}
-
-	return "", status.Error(codes.NotFound, fmt.Sprintf("failed to find VM with domain.firmware.uuid %v", nodeID))
 }
 
 func (c *ControllerService) getAllowedZoneAndRegion(_ context.Context, requirement *csi.TopologyRequirement) (string, string, error) {

--- a/pkg/service/driver.go
+++ b/pkg/service/driver.go
@@ -8,6 +8,11 @@ import (
 	"kubevirt.io/csi-driver/pkg/util"
 )
 
+const (
+	WellKnownRegionTopologyKey = "topology.kubernetes.io/region"
+	WellKnownZoneTopologyKey   = "topology.kubernetes.io/zone"
+)
+
 var (
 	// VendorVersion is the vendor version set by ldflags at build time
 	VendorVersion = "0.2.0"
@@ -30,7 +35,8 @@ func NewKubevirtCSIDriver(virtClient kubevirt.Client,
 	storageClassEnforcement util.StorageClassEnforcement,
 	nodeID string,
 	runNodeService bool,
-	runControllerService bool) *KubevirtCSIDriver {
+	runControllerService bool,
+	allowedTopologies map[string]string) *KubevirtCSIDriver {
 	d := KubevirtCSIDriver{
 		IdentityService: NewIdentityService(identityClientset),
 	}
@@ -45,7 +51,7 @@ func NewKubevirtCSIDriver(virtClient kubevirt.Client,
 	}
 
 	if runNodeService {
-		d.NodeService = NewNodeService(nodeID)
+		d.NodeService = NewNodeService(nodeID, allowedTopologies)
 	}
 
 	return &d

--- a/pkg/service/identity.go
+++ b/pkg/service/identity.go
@@ -69,6 +69,13 @@ func (i *IdentityService) GetPluginCapabilities(context.Context, *csi.GetPluginC
 					},
 				},
 			},
+			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -39,6 +39,7 @@ type NodeService struct {
 	resizer          ResizerInterface
 	devicePathGetter DevicePathGetter
 	dirMaker         dirMaker
+	allowedTopologies map[string]string
 }
 
 type DeviceLister interface {
@@ -100,7 +101,7 @@ var NewFsMaker = func() FsMaker {
 	})
 }
 
-func NewNodeService(nodeId string) *NodeService {
+func NewNodeService(nodeId string, allowedTopologies map[string]string) *NodeService {
 	return &NodeService{
 		nodeID:           nodeId,
 		deviceLister:     NewDeviceLister(),
@@ -108,6 +109,7 @@ func NewNodeService(nodeId string) *NodeService {
 		fsMaker:          NewFsMaker(),
 		mounter:          NewMounter(),
 		resizer:          NewResizer(),
+		allowedTopologies: allowedTopologies,
 		dirMaker: dirMakerFunc(func(path string, perm os.FileMode) error {
 			// MkdirAll returns nil if path already exists
 			return os.MkdirAll(path, perm)
@@ -444,7 +446,10 @@ func (n *NodeService) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 // NodeGetInfo returns the node ID
 func (n *NodeService) NodeGetInfo(context.Context, *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	// the nodeID is the VM's ID in kubevirt or VMI.spec.domain.firmware.uuid
-	return &csi.NodeGetInfoResponse{NodeId: n.nodeID}, nil
+
+	return &csi.NodeGetInfoResponse{
+		NodeId:             n.nodeID,
+		AccessibleTopology: &csi.Topology{Segments: n.allowedTopologies}}, nil
 }
 
 // NodeGetCapabilities returns the supported capabilities of the node service

--- a/sanity/sanity_suite_test.go
+++ b/sanity/sanity_suite_test.go
@@ -67,7 +67,11 @@ var _ = ginkgo.BeforeSuite(func() {
 		storagClassEnforcement,
 		getKey(infraClusterNamespace, nodeID),
 		true,
-		true)
+		true,
+		map[string]string{
+			service.WellKnownRegionTopologyKey: "eu-central-1",
+			service.WellKnownZoneTopologyKey:   "eu-central-1a",
+		})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	go func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This pull request introduces support for zone-aware topology in the KubeVirt CSI driver. This enhancement allows the CSI driver to handle storage provisioning and attachment in multi-zone Kubernetes clusters. Integrates with Kubernetes topology-aware volume provisioners to ensure volumes are created in the same zone/region as the requesting node by:

- Implements support for TopologyKeys to enable zone/region-specific volume scheduling and attachment
- Modifies the Controller plugin to handle topology constraints during volume provisioning
- Updates to the Node plugin to include zone information in NodeGetInfo responses

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support zone and region-aware topologies in the KubeVirt CSI Driver
```

