### PR TITLE
Set shell to bash in guest cluster node

### DIFF
--- a/hack/cluster-up.sh
+++ b/hack/cluster-up.sh
@@ -25,9 +25,10 @@ echo "Enable hotplug"
 #Add the feature gate to the resource of type Kubevirt.
 ./kubevirtci kubectl patch -n kubevirt kubevirt.kubevirt.io kubevirt  -p '{"spec":  { "configuration": { "developerConfiguration": { "featureGates": ["HotplugVolumes" ] }}}}' -o json --type merge
 
-# enables insecure registry
 for vmi in $(./kubevirtci kubectl get vmi -A --no-headers | awk '{ print $2 }')
 do
+        # enables insecure registry
         cat hack/vmi-insecure-registry | ./kubevirtci ssh-tenant $vmi $TENANT_CLUSTER_NAMESPACE
+        # sets shell to bash
+        echo 'sudo sed -i "s/home\/capk:.*/home\/capk:\/bin\/bash/g" /etc/passwd' | ./kubevirtci ssh-tenant $vmi $TENANT_CLUSTER_NAMESPACE
 done
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Right now the capk user on the guest nodes is using /bin/sh
which is resulting in a worse experience interacting with it over ssh.

Switch to /bin/bash so the experience is similar to infra node/local dev station.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

