### PR TITLE
Resize for extra capacity when restoring to greater target volume

### DIFF
--- a/hack/cluster-up.sh
+++ b/hack/cluster-up.sh
@@ -23,7 +23,7 @@ echo "Installing networking (calico)"
 
 echo "Enable hotplug"
 #Add the feature gate to the resource of type Kubevirt.
-./kubevirtci kubectl patch -n kubevirt kubevirt.kubevirt.io kubevirt  -p '{"spec":  { "configuration": { "developerConfiguration": { "featureGates": ["HotplugVolumes" ] }}}}' -o json --type merge
+./kubevirtci kubectl patch -n kubevirt kubevirt.kubevirt.io kubevirt  -p '{"spec":  { "configuration": { "developerConfiguration": { "featureGates": ["HotplugVolumes", "ExpandDisks"] }}}}' -o json --type merge
 
 for vmi in $(./kubevirtci kubectl get vmi -A --no-headers | awk '{ print $2 }')
 do

--- a/hack/run-k8s-e2e.sh
+++ b/hack/run-k8s-e2e.sh
@@ -108,7 +108,6 @@ spec:
             -ginkgo.focus='External.Storage.*csi.kubevirt.io.*' \
             -ginkgo.skip='CSI Ephemeral-volume*' \
             -ginkgo.skip='SELinuxMountReadWriteOncePod.*' \
-            -ginkgo.skip='should provision correct filesystem size when restoring snapshot to larger size pvc' \
             -storage.testdriver=\${TEST_DRIVER_PATH}/test-driver.yaml \
             -provider=local -report-dir=/tmp
       ret1=\$?

--- a/hack/run-linter.sh
+++ b/hack/run-linter.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+GOLANGCI_VERSION="${GOLANGCI_VERSION:-v1.64.8}"
+
 if [ ! -f "$(go env GOPATH)/bin/golangci-lint" ]; then
   # install golangci-lint
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin"
+  go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_VERSION}"
 fi
 
 golangci-lint run --verbose --timeout=10m

--- a/sanity/sanity_suite_test.go
+++ b/sanity/sanity_suite_test.go
@@ -33,6 +33,9 @@ var _ = ginkgo.BeforeSuite(func() {
 			values: make([]mountArgs, 0),
 		}
 	}
+	service.NewResizer = func() service.ResizerInterface {
+		return &fakeResizer{}
+	}
 	service.NewDeviceLister = func() service.DeviceLister {
 		return deviceLister
 	}

--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -354,3 +354,21 @@ type fakeFsMaker struct{}
 func (fm *fakeFsMaker) Make(device string, fsType string) error {
 	return nil
 }
+
+type fakeResizer struct {
+	resizedMap map[string]struct{}
+}
+
+func (r *fakeResizer) Resize(devicePath, deviceMountPath string) (bool, error) {
+	if r.resizedMap == nil {
+		r.resizedMap = map[string]struct{}{}
+	}
+	key := fmt.Sprintf("%s:%s", devicePath, deviceMountPath)
+	r.resizedMap[key] = struct{}{}
+
+	return true, nil
+}
+
+func (r *fakeResizer) NeedResize(devicePath string, deviceMountPath string) (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
While we do allow restoring to a greater target volume,
this was a no-op for fs volumes, because we never resized the fs
to make use of the new capacity.

This change always resizes the fs if necessary on volume publish.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: resize filesystems to make use of volumes that were restored to bigger target
```

