### PR TITLE
fix flaking k8s e2e lane

### DIFF
--- a/deploy/tenant/base/kustomization.yaml
+++ b/deploy/tenant/base/kustomization.yaml
@@ -1,9 +1,4 @@
 commonLabels:
   app: kubevirt-csi-driver
 resources:
-- rbac-snapshot-controller.yaml
-- setup-snapshot-controller.yaml
-- snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-- snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-- snapshot.storage.k8s.io_volumesnapshots.yaml
 - deploy.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
stop applying snapshot controller twice
this was resulting in the clusterrolebinding.subject
namespace getting overriden via kustomize:
https://github.com/kubernetes-sigs/kustomize/issues/880#issuecomment-499615583

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

