### PR TITLE
Ensure unpublish works for volumes carried over upgrades

### DIFF
--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -61,6 +61,7 @@ type Client interface {
 	GetDataVolume(ctx context.Context, namespace string, name string) (*cdiv1.DataVolume, error)
 	AddVolumeToVM(ctx context.Context, namespace string, vmName string, hotPlugRequest *kubevirtv1.AddVolumeOptions) error
 	RemoveVolumeFromVM(ctx context.Context, namespace string, vmName string, hotPlugRequest *kubevirtv1.RemoveVolumeOptions) error
+	RemoveVolumeFromVMI(ctx context.Context, namespace string, vmName string, hotPlugRequest *kubevirtv1.RemoveVolumeOptions) error
 	EnsureVolumeAvailable(ctx context.Context, namespace, vmName, volumeName string, timeout time.Duration) error
 	EnsureVolumeRemoved(ctx context.Context, namespace, vmName, volumeName string, timeout time.Duration) error
 	EnsureSnapshotReady(ctx context.Context, namespace, name string, timeout time.Duration) error
@@ -182,6 +183,20 @@ func (c *client) AddVolumeToVM(ctx context.Context, namespace string, vmName str
 // RemoveVolumeFromVM perform hotunplug of a DataVolume from a VM
 func (c *client) RemoveVolumeFromVM(ctx context.Context, namespace string, vmName string, hotPlugRequest *kubevirtv1.RemoveVolumeOptions) error {
 	uri := fmt.Sprintf(vmSubresourceURL, kubevirtv1.ApiStorageVersion, namespace, vmName, "removevolume")
+
+	JSON, err := json.Marshal(hotPlugRequest)
+
+	if err != nil {
+		return err
+	}
+
+	return c.restClient.Put().AbsPath(uri).Body([]byte(JSON)).Do(ctx).Error()
+}
+
+// RemoveVolumeFromVMI perform hotunplug of a DataVolume from a VMI
+func (c *client) RemoveVolumeFromVMI(ctx context.Context, namespace string, vmName string, hotPlugRequest *kubevirtv1.RemoveVolumeOptions) error {
+	vmiSubresourceURL := "/apis/subresources.kubevirt.io/%s/namespaces/%s/virtualmachineinstances/%s/%s"
+	uri := fmt.Sprintf(vmiSubresourceURL, kubevirtv1.ApiStorageVersion, namespace, vmName, "removevolume")
 
 	JSON, err := json.Marshal(hotPlugRequest)
 

--- a/pkg/kubevirt/mocked_client.go
+++ b/pkg/kubevirt/mocked_client.go
@@ -269,3 +269,17 @@ func (mr *MockClientMockRecorder) RemoveVolumeFromVM(ctx, namespace, vmName, hot
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVolumeFromVM", reflect.TypeOf((*MockClient)(nil).RemoveVolumeFromVM), ctx, namespace, vmName, hotPlugRequest)
 }
+
+// RemoveVolumeFromVMI mocks base method.
+func (m *MockClient) RemoveVolumeFromVMI(ctx context.Context, namespace, vmName string, hotPlugRequest *v10.RemoveVolumeOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveVolumeFromVMI", ctx, namespace, vmName, hotPlugRequest)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveVolumeFromVMI indicates an expected call of RemoveVolumeFromVMI.
+func (mr *MockClientMockRecorder) RemoveVolumeFromVMI(ctx, namespace, vmName, hotPlugRequest interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVolumeFromVMI", reflect.TypeOf((*MockClient)(nil).RemoveVolumeFromVMI), ctx, namespace, vmName, hotPlugRequest)
+}

--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -190,6 +190,10 @@ func (k *fakeKubeVirtClient) RemoveVolumeFromVM(_ context.Context, namespace str
 	return nil
 }
 
+func (k *fakeKubeVirtClient) RemoveVolumeFromVMI(_ context.Context, namespace string, vmName string, hotPlugRequest *kubevirtv1.RemoveVolumeOptions) error {
+	return nil
+}
+
 func (k *fakeKubeVirtClient) EnsureVolumeAvailable(_ context.Context, namespace, vmName, volumeName string, timeout time.Duration) error {
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
One upgrade consideration missed in PR 130 is that
ControllerUnpublish could be called against a VMI-level-hotplugged
carry over from an older driver version.
In that case, we would not issue a removevolume call
at all and fail in ensuring the volume got removed.

ControllerPublish doesn't suffer from a similar issue
since the volume would just get added on the VM level in addition.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Follow up vm level hotplug by ensuring correct handling of carry over from older versions
```

