### PR TITLE
Fix deployment pointing to old repository in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Running the functional tests will use an existing cluster (looks for `KUBECONFIG
 and will deploy the CSI driver on it, and a test pod that consumes a dynamically provisioned volume.
 
 ```shell
-make test-functional IMG=quay.io/kubevirt/csi-driver:latest
+make test-functional IMG=quay.io/kubevirt/kubevirt-csi-driver:latest
 ```
 
 You can choose to run the tests on a specific namespace. That namespace will not be terminated in the end of the run.

--- a/deploy/controller-infra/base/deploy.yaml
+++ b/deploy/controller-infra/base/deploy.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: csi-driver
           imagePullPolicy: Always
-          image: quay.io/kubevirt/csi-driver:latest
+          image: quay.io/kubevirt/kubevirt-csi-driver:latest
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"

--- a/deploy/controller-tenant/base/deploy.yaml
+++ b/deploy/controller-tenant/base/deploy.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: csi-driver
           imagePullPolicy: Always
-          image: quay.io/kubevirt/csi-driver:latest
+          image: quay.io/kubevirt/kubevirt-csi-driver:latest
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"

--- a/deploy/tenant/base/deploy.yaml
+++ b/deploy/tenant/base/deploy.yaml
@@ -205,7 +205,7 @@ spec:
             privileged: true
             allowPrivilegeEscalation: true
           imagePullPolicy: Always
-          image: quay.io/kubevirt/csi-driver:latest
+          image: quay.io/kubevirt/kubevirt-csi-driver:latest
           args:
             - "--endpoint=unix:/csi/csi.sock"
             - "--node-name=$(KUBE_NODE_NAME)"

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -110,7 +110,7 @@ spec:
       containers:
         - name: csi-driver
           imagePullPolicy: Always
-          image: quay.io/kubevirt/csi-driver:latest
+          image: quay.io/kubevirt/kubevirt-csi-driver:latest
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"
@@ -379,7 +379,7 @@ spec:
       containers:
         - name: csi-driver
           imagePullPolicy: Always
-          image: quay.io/kubevirt/csi-driver:latest
+          image: quay.io/kubevirt/kubevirt-csi-driver:latest
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"
@@ -1065,7 +1065,7 @@ spec:
             privileged: true
             allowPrivilegeEscalation: true
           imagePullPolicy: Always
-          image: quay.io/kubevirt/csi-driver:latest
+          image: quay.io/kubevirt/kubevirt-csi-driver:latest
           args:
             - "--endpoint=unix:/csi/csi.sock"
             - "--node-name=$(KUBE_NODE_NAME)"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Updated the example deployment scripts to point to the right repository.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #139 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

