### PR TITLE
Fix regression: always run EnsureVolumeRemoved during detach

### DIFF
--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -483,14 +483,15 @@ func (c *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 			klog.Infof("failed removing volume %s from VM %s, err: %v", dvName, vmName, err)
 			return false, nil
 		}
+
+		err = c.virtClient.EnsureVolumeRemoved(ctx, c.infraClusterNamespace, vmName, dvName, time.Minute*2)
+		if err != nil {
+			klog.Errorf("volume %s failed to be removed in time (2m) from VM %s, %v", dvName, vmName, err)
+			return false, nil
+		}
+
 		return true, nil
 	}); err != nil {
-		return nil, err
-	}
-
-	err = c.virtClient.EnsureVolumeRemoved(ctx, c.infraClusterNamespace, vmName, dvName, time.Minute*2)
-	if err != nil {
-		klog.Errorf("volume %s failed to be removed in time (2m) from VM %s, %v", dvName, vmName, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>



**What this PR does / why we need it**:


 - #90
   correctly added `EnsureVolumeRemoved()` to wait until a hot-plug disk is really detached before returning success.
 - #93
   wrapped the detach call in a 5-step ExponentialBackoff (~31 s), but left `EnsureVolumeRemoved()` outside that loop. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

