### PR TITLE
Fix deadlock while reattaching volume

### DIFF
--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -209,6 +209,14 @@ func (k *fakeKubeVirtClient) EnsureVolumeAvailable(_ context.Context, namespace,
 	return nil
 }
 
+func (c *fakeKubeVirtClient) EnsureVolumeAvailableVM(_ context.Context, namespace, vmName, volName string) (bool, error) {
+	return false, nil
+}
+
+func (c *fakeKubeVirtClient) EnsureVolumeRemovedVM(_ context.Context, namespace, vmName, volName string) (bool, error) {
+	return false, nil
+}
+
 func (k *fakeKubeVirtClient) EnsureVolumeRemoved(_ context.Context, namespace, vmName, volumeName string, timeout time.Duration) error {
 	return nil
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR adds logic that prevents the controller from trying to attach or detach a volume when the VMI status already shows the volume is in the desired state.

**Which issue(s) this PR fixes** 


We ran into a problem while a volume was being attached. The attacher logged:

```
I0630 08:45:50.046983       1 csi_handler.go:243] "Error processing" VolumeAttachment="csi-6da36ea7aa56330cd69c4061f0a7e0266a7e08d3dd819943acab55922f5e764d" err="failed to detach: rpc error: code = Internal desc = ControllerUnpublishVolume failed for pvc-0645b5aa-75c0-4f00-ac2d-a9998256fa65: Message: 'Resource 'pvc-0645b5aa-75c0-4f00-ac2d-a9998256fa65' is still in use.'; Cause: 'Resource is mounted/in use.'; Details: 'Node: plo-csxhk-004, Resource: pvc-0645b5aa-75c0-4f00-ac2d-a9998256fa65'; Correction: 'Un-mount resource 'pvc-0645b5aa-75c0-4f00-ac2d-a9998256fa65' on the node 'plo-csxhk-004'.'; Reports: '[685C0CB4-00000-002093]'"
```

On the node the disk was already attached to the VM, yet the corresponding VolumeAttachment had a deletion timestamp.

So we got stuck: the hp-volume pod couldn’t start because it was waiting for the VolumeAttachment to disappear, and the VolumeAttachment couldn’t be removed because the VM was still using the disk.

This may be a race: kubevirt-csi-controller thought the disk had been detached (the hp-volume pod was gone), while the VM was still holding it. Kubernetes then created a new VolumeAttachment in the tenant cluster, triggering another attach operation.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix deadlock while reattaching volume
```

