### PR TITLE
Refactor KubeVirtCSIDriver creation

### DIFF
--- a/cmd/kubevirt-csi-driver/config.go
+++ b/cmd/kubevirt-csi-driver/config.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	snapcli "kubevirt.io/csi-driver/pkg/generated/external-snapshotter/client-go/clientset/versioned"
+	"kubevirt.io/csi-driver/pkg/kubevirt"
+	"kubevirt.io/csi-driver/pkg/util"
+)
+
+type config struct {
+	endpoint                     string
+	nodeName                     string
+	infraClusterNamespace        string
+	infraClusterKubeconfig       string
+	infraClusterLabels           string
+	volumePrefix                 string
+	infraStorageClassEnforcement string
+
+	tenantClusterKubeconfig string
+
+	runNodeService       bool
+	runControllerService bool
+
+	// Client section.
+	tenantConfig            *rest.Config
+	infraConfig             *rest.Config
+	tenantClientset         kubernetes.Interface
+	tenantSnapshotClientset snapcli.Interface
+	infraClientset          kubernetes.Interface
+	virtClient              kubevirt.Client
+}
+
+func (c *config) getTenantConfig() (*rest.Config, error) {
+	if c.tenantConfig != nil {
+		return c.tenantConfig, nil
+	}
+
+	rc, err := getConfigOrInCluster(c.tenantClusterKubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tenant rest config: %w", err)
+	}
+
+	c.tenantConfig = rc
+	return c.tenantConfig, nil
+}
+
+func (c *config) getInfraConfig() (*rest.Config, error) {
+	if c.infraConfig != nil {
+		return c.infraConfig, nil
+	}
+
+	rc, err := getConfigOrInCluster(c.infraClusterKubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get infra rest config: %w", err)
+	}
+
+	c.infraConfig = rc
+	return c.infraConfig, nil
+}
+
+func (c *config) getTenantClientset() (kubernetes.Interface, error) {
+	if c.tenantClientset != nil {
+		return c.tenantClientset, nil
+	}
+
+	rc, err := c.getTenantConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	tc, err := kubernetes.NewForConfig(rc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build tenant client set: %w", err)
+	}
+
+	c.tenantClientset = tc
+	return c.tenantClientset, nil
+}
+
+func (c *config) getTenantSnapshotClientset() (snapcli.Interface, error) {
+	if c.tenantSnapshotClientset != nil {
+		return c.tenantSnapshotClientset, nil
+	}
+
+	rc, err := c.getTenantConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	tc, err := snapcli.NewForConfig(rc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build tenant snapshot client set: %w", err)
+	}
+
+	c.tenantSnapshotClientset = tc
+	return c.tenantSnapshotClientset, nil
+}
+
+func (c *config) getInfraClientset() (kubernetes.Interface, error) {
+	if c.infraClientset != nil {
+		return c.infraClientset, nil
+	}
+
+	rc, err := c.getInfraConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	tc, err := kubernetes.NewForConfig(rc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build infra client set: %w", err)
+	}
+
+	c.infraClientset = tc
+	return c.infraClientset, nil
+}
+
+func (c *config) getVirtClient(
+	infraClusterLabelsMap map[string]string,
+	storageClassEnforcement util.StorageClassEnforcement,
+) (kubevirt.Client, error) {
+	if c.virtClient != nil {
+		return c.virtClient, nil
+	}
+
+	// Perform precheck.
+	if c.volumePrefix == "" {
+		return nil, errors.New("volume-prefix must be set when deploying the controller")
+	}
+
+	// Get rest configs.
+	rc, err := c.getInfraConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get required clientsets.
+	tc, err := c.getTenantClientset()
+	if err != nil {
+		return nil, err
+	}
+	tsc, err := c.getTenantSnapshotClientset()
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize virt client.
+	vc, err := kubevirt.NewClient(
+		rc,
+		infraClusterLabelsMap,
+		tc,
+		tsc,
+		storageClassEnforcement,
+		c.volumePrefix,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize virt client: %w", err)
+	}
+
+	c.virtClient = vc
+	return c.virtClient, nil
+}
+
+// getConfigOrInCluster loads the Kubernetes REST config.
+// If the kubeconfig path is empty, it attempts to load the in-cluster configuration.
+func getConfigOrInCluster(kubeconfig string) (*rest.Config, error) {
+	if kubeconfig == "" {
+		// Fallback to in cluster config.
+		inClusterConfig, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build in cluster config: %w", err)
+		}
+		return inClusterConfig, nil
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build cluster config: %w", err)
+	}
+	return config, nil
+}

--- a/deploy/controller-tenant/base/deploy.yaml
+++ b/deploy/controller-tenant/base/deploy.yaml
@@ -37,6 +37,8 @@ spec:
             - "--infra-cluster-namespace=$(INFRACLUSTER_NAMESPACE)"
             - "--infra-cluster-kubeconfig=/var/run/secrets/infracluster/kubeconfig"
             - "--infra-cluster-labels=$(INFRACLUSTER_LABELS)"
+            - "--run-node-service=false"
+            - "--run-controller-service=true"
             - "--v=5"
           ports:
             - name: healthz

--- a/hack/cluster-sync-split.sh
+++ b/hack/cluster-sync-split.sh
@@ -103,5 +103,5 @@ _kubectl apply --kustomize ./deploy/controller-infra/dev-overlay
 _kubectl_tenant rollout restart ds/kubevirt-csi-node -n $CSI_DRIVER_NAMESPACE
 _kubectl rollout restart deployment/kubevirt-csi-controller -n $TENANT_CLUSTER_NAMESPACE
 
-_kubectl_tenant rollout status ds/kubevirt-csi-node -n $CSI_DRIVER_NAMESPACE --timeout=10m
-_kubectl rollout status deployment/kubevirt-csi-controller -n $TENANT_CLUSTER_NAMESPACE --timeout=10m
+wait::check_rollout "_kubectl_tenant" "ds" "kubevirt-csi-node" "$CSI_DRIVER_NAMESPACE" "10m"
+wait::check_rollout "_kubectl" "deployment" "kubevirt-csi-controller" "$TENANT_CLUSTER_NAMESPACE" "10m"

--- a/hack/cluster-sync.sh
+++ b/hack/cluster-sync.sh
@@ -125,5 +125,5 @@ _kubectl_tenant apply --kustomize ./deploy/controller-tenant/dev-overlay
 # ******************************************************
 # Wait for driver to rollout
 # ******************************************************
-_kubectl_tenant rollout status ds/kubevirt-csi-node -n $CSI_DRIVER_NAMESPACE --timeout=5m
-_kubectl_tenant rollout status deployment/kubevirt-csi-controller -n $CSI_DRIVER_NAMESPACE --timeout=5m
+wait::check_rollout "_kubectl_tenant" "ds" "kubevirt-csi-node" "$CSI_DRIVER_NAMESPACE" "5m"
+wait::check_rollout "_kubectl_tenant" "deployment" "kubevirt-csi-controller" "$CSI_DRIVER_NAMESPACE" "5m"

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -21,6 +21,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	"kubevirt.io/csi-driver/pkg/kubevirt"
 	client "kubevirt.io/csi-driver/pkg/kubevirt"
 	"kubevirt.io/csi-driver/pkg/util"
 )
@@ -44,6 +45,21 @@ type ControllerService struct {
 	infraClusterNamespace   string
 	infraClusterLabels      map[string]string
 	storageClassEnforcement util.StorageClassEnforcement
+}
+
+// NewControllerService creates a new instance of ControllerService.
+func NewControllerService(
+	virtClient kubevirt.Client,
+	infraClusterNamespace string,
+	infraClusterLabels map[string]string,
+	storageClassEnforcement util.StorageClassEnforcement,
+) *ControllerService {
+	return &ControllerService{
+		virtClient:              virtClient,
+		infraClusterNamespace:   infraClusterNamespace,
+		infraClusterLabels:      infraClusterLabels,
+		storageClassEnforcement: storageClassEnforcement,
+	}
 }
 
 var controllerCaps = []csi.ControllerServiceCapability_RPC_Type{

--- a/sanity/sanity_suite_test.go
+++ b/sanity/sanity_suite_test.go
@@ -59,14 +59,19 @@ var _ = ginkgo.BeforeSuite(func() {
 		AllowDefault: true,
 	}
 
-	driver := service.NewKubevirtCSIDriver(virtClient,
-		identityClientset,
-		infraClusterNamespace,
-		infraClusterLabelsMap,
-		storagClassEnforcement,
-		getKey(infraClusterNamespace, nodeID),
-		true,
-		true)
+	driver := service.NewKubevirtCSIDriver().
+		WithIdentityService(
+			identityClientset,
+		).
+		WithControllerService(
+			virtClient,
+			infraClusterNamespace,
+			infraClusterLabelsMap,
+			storagClassEnforcement,
+		).
+		WithNodeService(
+			getKey(infraClusterNamespace, nodeID),
+		)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	go func() {


### PR DESCRIPTION
The logic and dependencies on the creation of the Controller and the Node services differ. Splitting them will make them more manageable.

While trying to keep the functionality, there are a few key differences:
1. A nodeName is required to run the Node service
2. If both the Controller and Node service are being run from the cmd binary, it will fallback to the identity controller in the tenant clientset. As far as I understand, running both services from the same binary (as in, within the same pod) is not a valid scenario, with the only instance i found being in the sanity test.

I'll follow with some testing.

**What this PR does / why we need it**:
Refactors KubeVirtCSIDriver creation and KubeVirtCSI binary entry point. Separates Controller and Node service creation to facilitate updates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This started off from introducing informers and a fix to RWO volumes having two different volume attachments at the same time. There will be follow ups to cover those linked to this PR. While working on that, I noticed that a refactor may be useful.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

