### PR TITLE
Add DataVolume Finalizer

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,5 +1,9 @@
 package util
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 type StorageClassEnforcement struct {
 	AllowList              []string                 `yaml:"allowList"`
 	AllowAll               bool                     `yaml:"allowAll"`
@@ -16,6 +20,47 @@ type StorageSnapshotMapping struct {
 func Contains(arr []string, val string) bool {
 	for _, itrVal := range arr {
 		if val == itrVal {
+			return true
+		}
+	}
+	return false
+}
+
+// AddFinalizer accepts an Object and adds the provided finalizer if not present.
+// It returns an indication of whether it updated the object's list of finalizers.
+func AddFinalizer(o metav1.Object, finalizer string) (finalizersUpdated bool) {
+	f := o.GetFinalizers()
+	for _, e := range f {
+		if e == finalizer {
+			return false
+		}
+	}
+	o.SetFinalizers(append(f, finalizer))
+	return true
+}
+
+// RemoveFinalizer accepts an Object and removes the provided finalizer if present.
+// It returns an indication of whether it updated the object's list of finalizers.
+func RemoveFinalizer(o metav1.Object, finalizer string) (finalizersUpdated bool) {
+	f := o.GetFinalizers()
+	length := len(f)
+
+	index := 0
+	for i := 0; i < length; i++ {
+		if f[i] == finalizer {
+			continue
+		}
+		f[index] = f[i]
+		index++
+	}
+	o.SetFinalizers(f[:index])
+	return length != index
+}
+
+// ContainsFinalizer checks an Object that the provided finalizer is present.
+func ContainsFinalizer(o metav1.Object, finalizer string) bool {
+	for _, f := range o.GetFinalizers() {
+		if f == finalizer {
 			return true
 		}
 	}


### PR DESCRIPTION
Add a finalizer to the DataVolume to prevent it from being accidentally deleted manually or by external workloads.

**What this PR does / why we need it**:
I encountered a scenario where some DataVolumes were accidentally deleted, leading to data loss and VMs being unable to boot. As a precaution, a DataVolume created by KVCSI should have a finalizer to prevent it from being accidentally deleted, ensuring resources are cleaned up properly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
Added finalizer "cdi.kubevirt.io/user-volume-protection" to DataVolume.

```

