### PR TITLE
Add udev rescan on NodeStage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL maintainers="The KubeVirt Project <kubevirt-dev@googlegroups.com>" \
 
 ENTRYPOINT ["./kubevirt-csi-driver"]
 
-RUN dnf install -y e2fsprogs xfsprogs && dnf clean all
+RUN dnf install -y e2fsprogs xfsprogs systemd-udevd && dnf clean all
 
 ARG git_sha=NONE
 LABEL multi.GIT_SHA=${git_sha}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/openshift/build-machinery-go v0.0.0-20240613134303-8359781da660
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/net v0.33.0
+	golang.org/x/sys v0.28.0
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/yaml.v2 v2.4.0
@@ -63,7 +64,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
-	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.3.0 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When KubeVirt adds a volume to the guest OS, it is possible that the event trigger for udev fails. In these cases, there is no additional trigger to ever rerun the scan. This can result in a failure indicated by `couldn't find device by serial id` and is unrecoverable without manual intervention.

This change address this by adding a udevadm trigger on a specified block device in the `getDeviceBySerialID` loop when it sees a device with an empty serial ID.

**Which issue(s) this PR fixes**:
Fixes #152 

**Special notes for your reviewer**:
The unit testing added effectively creates a script called `udevadm` and add it to $PATH. This allows the unit testing to preempt the udevadm call within code and validate both input values and mock output values.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
While this change will not break existing setup, for it to be effective, host `/sys` must be mounted in the NodeService Pods or be otherwise accessible.
```

