### PR TITLE
Allow propagation of annotations from tenant to infra PVC

### DIFF
--- a/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
+++ b/cmd/kubevirt-csi-driver/kubevirt-csi-driver.go
@@ -21,12 +21,13 @@ import (
 )
 
 var (
-	endpoint               = flag.String("endpoint", "unix:/csi/csi.sock", "CSI endpoint")
-	nodeName               = flag.String("node-name", "", "The node name - the node this pods runs on")
-	infraClusterNamespace  = flag.String("infra-cluster-namespace", "", "The infra-cluster namespace")
-	infraClusterKubeconfig = flag.String("infra-cluster-kubeconfig", "", "the infra-cluster kubeconfig file. If not set, defaults to in cluster config.")
-	infraClusterLabels     = flag.String("infra-cluster-labels", "", "The infra-cluster labels to use when creating resources in infra cluster. 'name=value' fields separated by a comma")
-	volumePrefix           = flag.String("volume-prefix", "pvc", "The prefix expected for persistent volumes")
+	endpoint                 = flag.String("endpoint", "unix:/csi/csi.sock", "CSI endpoint")
+	nodeName                 = flag.String("node-name", "", "The node name - the node this pods runs on")
+	infraClusterNamespace    = flag.String("infra-cluster-namespace", "", "The infra-cluster namespace")
+	infraClusterKubeconfig   = flag.String("infra-cluster-kubeconfig", "", "the infra-cluster kubeconfig file. If not set, defaults to in cluster config.")
+	infraClusterLabels       = flag.String("infra-cluster-labels", "", "The infra-cluster labels to use when creating resources in infra cluster. 'name=value' fields separated by a comma")
+	volumePrefix             = flag.String("volume-prefix", "pvc", "The prefix expected for persistent volumes")
+	annotationsAllowlistPath = flag.String("annotations-allowlist-path", "", "The path to the file containing the allowed annotations.")
 	// infraStorageClassEnforcement = flag.String("infra-storage-class-enforcement", "", "A string encoded yaml that represents the policy of enforcing which infra storage classes are allowed in persistentVolume of type kubevirt")
 	infraStorageClassEnforcement = os.Getenv("INFRA_STORAGE_CLASS_ENFORCEMENT")
 
@@ -134,7 +135,8 @@ func handle() {
 		storageClassEnforcement,
 		nodeID,
 		*runNodeService,
-		*runControllerService)
+		*runControllerService,
+		*annotationsAllowlistPath)
 
 	driver.Run(*endpoint)
 }

--- a/pkg/service/controller_test.go
+++ b/pkg/service/controller_test.go
@@ -947,7 +947,10 @@ func (c *ControllerClientMock) GetDataVolume(_ context.Context, namespace string
 	}
 	return dv, nil
 }
-func (c *ControllerClientMock) GetPersistentVolumeClaim(_ context.Context, namespace string, claimName string) (*corev1.PersistentVolumeClaim, error) {
+func (c *ControllerClientMock) GetTenantPersistentVolumeClaim(_ context.Context, namespace string, claimName string) (*corev1.PersistentVolumeClaim, error) {
+	return nil, errors.New("Not implemented")
+}
+func (c *ControllerClientMock) GetInfraPersistentVolumeClaim(_ context.Context, namespace string, claimName string) (*corev1.PersistentVolumeClaim, error) {
 	return nil, errors.New("Not implemented")
 }
 func (c *ControllerClientMock) ExpandPersistentVolumeClaim(_ context.Context, namespace string, claimName string, size int64) error {

--- a/pkg/service/driver.go
+++ b/pkg/service/driver.go
@@ -30,17 +30,19 @@ func NewKubevirtCSIDriver(virtClient kubevirt.Client,
 	storageClassEnforcement util.StorageClassEnforcement,
 	nodeID string,
 	runNodeService bool,
-	runControllerService bool) *KubevirtCSIDriver {
+	runControllerService bool,
+	annotationsAllowlistPath string) *KubevirtCSIDriver {
 	d := KubevirtCSIDriver{
 		IdentityService: NewIdentityService(identityClientset),
 	}
 
 	if runControllerService {
 		d.ControllerService = &ControllerService{
-			virtClient:              virtClient,
-			infraClusterNamespace:   infraClusterNamespace,
-			infraClusterLabels:      infraClusterLabels,
-			storageClassEnforcement: storageClassEnforcement,
+			virtClient:               virtClient,
+			infraClusterNamespace:    infraClusterNamespace,
+			infraClusterLabels:       infraClusterLabels,
+			storageClassEnforcement:  storageClassEnforcement,
+			annotationsAllowlistPath: annotationsAllowlistPath,
 		}
 	}
 

--- a/pkg/util/annotations.go
+++ b/pkg/util/annotations.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"bufio"
+	"os"
+)
+
+// FilterAndMergeAnnotations will take a source and a target annotations. It will
+// get all values for the annotations in filterAnnotations, and place the value
+// in target.
+func FilterAndMergeAnnotations(source, target map[string]string, annotationsAllowlistPath string) map[string]string {
+	if target == nil {
+		target = map[string]string{}
+	}
+	for _, annotation := range readAllowedAnnotations(annotationsAllowlistPath) {
+		if val, ok := source[annotation]; ok {
+			target[annotation] = val
+		}
+	}
+	return target
+}
+
+func readAllowedAnnotations(annotationsAllowlistPath string) []string {
+	if annotationsAllowlistPath == "" {
+		return []string{}
+	}
+
+	allowlist, err := os.Open(annotationsAllowlistPath)
+	if err != nil {
+		return []string{}
+	}
+	defer allowlist.Close()
+
+	var annotations []string
+	scanner := bufio.NewScanner(allowlist)
+	for scanner.Scan() {
+		annotations = append(annotations, scanner.Text())
+	}
+	return annotations
+}

--- a/pkg/util/annotations_test.go
+++ b/pkg/util/annotations_test.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFilterAndMergeAnnotations(t *testing.T) {
+	tests := []struct {
+		name   string
+		source map[string]string
+		target map[string]string
+		want   map[string]string
+	}{
+		{
+			name: "Empty",
+			want: map[string]string{},
+		},
+		{
+			name: "Unfiltered",
+			source: map[string]string{
+				"ignore.io": "test",
+			},
+			target: map[string]string{
+				"result.io": "pass",
+			},
+			want: map[string]string{
+				"result.io": "pass",
+			},
+		},
+		{
+			name: "Filtered",
+			source: map[string]string{
+				"cdi.kubevirt.io/externalPopulation": "true",
+			},
+			target: map[string]string{
+				"result.io": "pass",
+			},
+			want: map[string]string{
+				"result.io":                          "pass",
+				"cdi.kubevirt.io/externalPopulation": "true",
+			},
+		},
+		{
+			name: "FilteredIntoEmpty",
+			source: map[string]string{
+				"cdi.kubevirt.io/externalPopulation": "true",
+			},
+			want: map[string]string{
+				"cdi.kubevirt.io/externalPopulation": "true",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := FilterAndMergeAnnotations(test.source, test.target, "")
+			if diff := cmp.Diff(result, test.want); diff != "" {
+				t.Errorf("MergeAnnotations(): returned unexpected diff (+got, -want):\n%v", diff)
+			}
+		})
+	}
+}

--- a/sanity/sanity_suite_test.go
+++ b/sanity/sanity_suite_test.go
@@ -66,7 +66,8 @@ var _ = ginkgo.BeforeSuite(func() {
 		storagClassEnforcement,
 		getKey(infraClusterNamespace, nodeID),
 		true,
-		true)
+		true,
+		"")
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	go func() {

--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -160,7 +160,12 @@ func (k *fakeKubeVirtClient) GetDataVolume(_ context.Context, namespace string, 
 	return k.dvMap[key], nil
 }
 
-func (k *fakeKubeVirtClient) GetPersistentVolumeClaim(_ context.Context, namespace string, claimName string) (*corev1.PersistentVolumeClaim, error) {
+func (k *fakeKubeVirtClient) GetTenantPersistentVolumeClaim(_ context.Context, namespace string, claimName string) (*corev1.PersistentVolumeClaim, error) {
+	// Figure out correct impl. for sanity
+	return nil, nil
+}
+
+func (k *fakeKubeVirtClient) GetInfraPersistentVolumeClaim(_ context.Context, namespace string, claimName string) (*corev1.PersistentVolumeClaim, error) {
 	// Figure out correct impl. for sanity
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it so that selected annotations (based on a configmap) can be propagated from the tenant PVC to the infra PVC. 

Usage: 
An annotation on the tenant PVC could be used to communicate the desired QoS policy among other possible configurations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/csi-driver/issues/172

**Special notes for your reviewer**:

```release-note
Allow propagation of selected annotations from tenant to infra PVCs.
```

