### PR TITLE
Fix silent error swallowing in makeFS and getDeviceBySerialID

### DIFF
--- a/pkg/service/node.go
+++ b/pkg/service/node.go
@@ -542,9 +542,12 @@ func getDeviceBySerialID(serialID string, deviceLister DeviceLister) (device, er
 	klog.Infof("Get the device details by serialID %s", serialID)
 
 	out, err := deviceLister.List()
-	exitError, incompleteCmd := err.(*exec.ExitError)
-	if err != nil && incompleteCmd {
-		return device{}, errors.New(err.Error() + "lsblk failed with " + string(exitError.Stderr))
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			return device{}, errors.New(err.Error() + " lsblk failed with " + string(exitError.Stderr))
+		}
+		return device{}, err
 	}
 
 	devices := devices{}
@@ -582,11 +585,14 @@ func makeFS(device string, fsType string) error {
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
-	exitError, incompleteCmd := err.(*exec.ExitError)
-	if err != nil && incompleteCmd {
-		klog.Errorf("stdout: %s", stdout.String())
-		klog.Errorf("stderr: %s", stdout.String())
-		return errors.New(err.Error() + " mkfs failed with " + exitError.Error())
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			klog.Errorf("stdout: %s", stdout.String())
+			klog.Errorf("stderr: %s", stderr.String())
+			return errors.New(err.Error() + " mkfs failed with " + exitError.Error())
+		}
+		return err
 	}
 
 	return nil

--- a/pkg/service/node_test.go
+++ b/pkg/service/node_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
@@ -47,6 +48,54 @@ var _ = Describe("NodeService", func() {
 	})
 
 	Context("Staging a volume", func() {
+		It("should propagate non-ExitError failures from deviceLister", func() {
+			underTest.deviceLister = deviceListerFunc(func() ([]byte, error) {
+				return nil, fmt.Errorf("exec: \"lsblk\": executable file not found in $PATH")
+			})
+
+			_, err := underTest.NodeStageVolume(context.TODO(), &csi.NodeStageVolumeRequest{
+				VolumeId: "pvc-123",
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							FsType: "ext4",
+						},
+					},
+				},
+				VolumeContext:     map[string]string{serialParameter: serialID},
+				StagingTargetPath: "/staging/path",
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("executable file not found"))
+		})
+
+		It("should include stderr details when deviceLister returns an ExitError", func() {
+			underTest.deviceLister = deviceListerFunc(func() ([]byte, error) {
+				return nil, &exec.ExitError{
+					ProcessState: nil,
+					Stderr:       []byte("lsblk: permission denied"),
+				}
+			})
+
+			_, err := underTest.NodeStageVolume(context.TODO(), &csi.NodeStageVolumeRequest{
+				VolumeId: "pvc-123",
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{
+							FsType: "ext4",
+						},
+					},
+				},
+				VolumeContext:     map[string]string{serialParameter: serialID},
+				StagingTargetPath: "/staging/path",
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("lsblk failed with"))
+			Expect(err.Error()).To(ContainSubstring("lsblk: permission denied"))
+		})
+
 		It("should fail with non-matching serial ID", func() {
 			_, err := underTest.NodeStageVolume(context.TODO(), &csi.NodeStageVolumeRequest{
 				VolumeId:      "pvc-123",
@@ -263,6 +312,24 @@ var _ = Describe("NodeService", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).ToNot(BeNil())
 		})
+	})
+})
+
+var _ = Describe("makeFS", func() {
+	It("should return error when mkfs binary is not found", func() {
+		origPath := os.Getenv("PATH")
+		os.Setenv("PATH", "")
+		defer os.Setenv("PATH", origPath)
+
+		err := makeFS("/dev/fake", "ext4")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("executable file not found"))
+	})
+
+	It("should return error for unsupported filesystem type", func() {
+		err := makeFS("/dev/fake", "ntfs")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not supported"))
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Both `makeFS` and `getDeviceBySerialID` in `pkg/service/node.go` performed a type assertion to `*exec.ExitError` before checking if `err` was nil. When the error was non-nil but not an `*exec.ExitError` (e.g., `exec.ErrNotFound` when `mkfs` or `lsblk` is missing from `PATH`), the error-handling block was skipped entirely:
- **`makeFS`**: returned `nil`, causing `NodeStageVolume` to report success and mark the volume as staged **without a filesystem**. The volume became permanently unusable because kubelet would not retry a successful Stage, and subsequent `NodePublishVolume` mount calls would fail with a confusing error.
- **`getDeviceBySerialID`**: fell through to `json.Unmarshal` on nil output, replacing the real error with a misleading JSON parse error and misdirecting debugging.
This PR:
- Reorders error handling to check `err != nil` first, then attempts the `*exec.ExitError` match inside the guarded block
- Uses `errors.As` instead of direct type assertion for robustness against wrapped errors
- Fixes a pre-existing copy-paste bug that logged `stdout` in place of `stderr` in `makeFS`
- Fixes a missing space in the `getDeviceBySerialID` error message
- Adds unit tests for non-ExitError propagation in both functions
- Adds an ExitError regression test to ensure enriched error messages (with stderr details) still work


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

No behavioral change for the happy path or the ExitError path. The only change is that errors which were previously swallowed now correctly propagate.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

