### PR TITLE
Check VMI status when detaching, not just VM spec

### DIFF
--- a/pkg/kubevirt/client.go
+++ b/pkg/kubevirt/client.go
@@ -70,6 +70,7 @@ type Client interface {
 	EnsureVolumeAvailableVM(ctx context.Context, namespace, name, volumeName string) (bool, error)
 	EnsureVolumeRemoved(ctx context.Context, namespace, vmName, volumeName string, timeout time.Duration) error
 	EnsureVolumeRemovedVM(ctx context.Context, namespace, name, volumeName string) (bool, error)
+	EnsureVolumeRemovedVMI(ctx context.Context, namespace, name, volumeName string) (bool, error)
 	EnsureSnapshotReady(ctx context.Context, namespace, name string, timeout time.Duration) error
 	EnsureControllerResize(ctx context.Context, namespace, claimName string, timeout time.Duration) error
 	CreateVolumeSnapshot(ctx context.Context, namespace, name, claimName, snapshotClassName string) (*snapshotv1.VolumeSnapshot, error)
@@ -598,6 +599,34 @@ func (c *client) EnsureVolumeRemovedVM(ctx context.Context, namespace, name, vol
 			continue
 		}
 		if volume.Name == volumeName {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// EnsureVolumeRemovedVMI returns true when the VMI no longer reports the
+// volume as a hot-plug in its status. It is the live-state counterpart of
+// EnsureVolumeRemovedVM, which only inspects the VM spec. The two diverge
+// when the parent VM has been deleted but the VMI (and its hot-plug pod)
+// is still around, or when virt-api mutated VM.spec optimistically but
+// virt-handler has not unplugged the device yet.
+func (c *client) EnsureVolumeRemovedVMI(ctx context.Context, namespace, name, volumeName string) (bool, error) {
+	vmi, err := c.virtClient.KubevirtV1().VirtualMachineInstances(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return false, err
+		}
+		// No VMI, vacuously removed
+		return true, nil
+	}
+
+	for _, volumeStatus := range vmi.Status.VolumeStatus {
+		if volumeStatus.HotplugVolume == nil {
+			continue
+		}
+		if volumeStatus.Name == volumeName {
 			return false, nil
 		}
 	}

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -534,22 +534,17 @@ func (c *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 		klog.Error("failed getting VM Name for node ID " + req.NodeId)
 		return nil, err
 	}
-	_, err = c.virtClient.GetWorkloadManagingVirtualMachine(ctx, c.infraClusterNamespace, vmName)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, err
-		}
-		// VM removed, vacuously succeeded in unpublish
-		return nil, nil
-	}
-
-	// Fast-path: if the disk is no longer on the VM, succeed immediately
-	notPresent, err := c.virtClient.EnsureVolumeRemovedVM(ctx, c.infraClusterNamespace, vmName, dvName)
+	// We do NOT short-circuit on "VM not found" anymore. The VMI (and its
+	// hot-plug pod) can outlive the parent VM during a CAPI/CAPK teardown
+	// race; returning success here used to leave orphan hot-plug pods
+	// that hold the infra storage device exclusively attached to the source
+	// host — blocking subsequent attachments. See kubevirt/csi-driver#83.
+	attached, err := c.volumeStillAttached(ctx, vmName, dvName)
 	if err != nil {
 		return nil, err
 	}
-	if notPresent {
-		klog.V(3).Infof("Volume %s already detached from VM %s – skipping hot-unplug", dvName, vmName)
+	if !attached {
+		klog.V(3).Infof("Volume %s already detached from VM/VMI %s – skipping hot-unplug", dvName, vmName)
 		return &csi.ControllerUnpublishVolumeResponse{}, nil
 	}
 
@@ -578,38 +573,79 @@ func (c *ControllerService) ControllerUnpublishVolume(ctx context.Context, req *
 	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
-func (c *ControllerService) removeVolumeFromVm(ctx context.Context, dvName, vmName string) error {
-	vm, err := c.virtClient.GetWorkloadManagingVirtualMachine(ctx, c.infraClusterNamespace, vmName)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
-		klog.V(3).Info("managing VM not found, remove succeeded")
-		return nil
-	}
-	removePossibleVM := false
-	for _, volume := range vm.Spec.Template.Spec.Volumes {
-		if volume.DataVolume == nil {
-			continue
-		}
-		if volume.DataVolume.Hotpluggable && volume.Name == dvName {
-			removePossibleVM = true
-		}
-	}
-	if removePossibleVM {
-		// Detach DataVolume from VM
-		err = c.virtClient.RemoveVolumeFromVM(ctx, c.infraClusterNamespace, vmName, &kubevirtv1.RemoveVolumeOptions{Name: dvName})
-		if err != nil {
-			return err
-		}
-		// We're done
-		return nil
+// volumeStillAttached returns true when the disk is still referenced by either
+// the VM spec or the VMI hot-plug status. Both surfaces must be checked: the
+// VM spec alone can lag the VMI status during a virt-api/virt-handler split,
+// and the VM object itself can be gone while the VMI is still alive.
+func (c *ControllerService) volumeStillAttached(ctx context.Context, vmName, dvName string) (bool, error) {
+	vmGone := false
+	_, err := c.virtClient.GetWorkloadManagingVirtualMachine(ctx, c.infraClusterNamespace, vmName)
+	switch {
+	case err == nil:
+	case errors.IsNotFound(err):
+		vmGone = true
+	default:
+		return false, err
 	}
 
-	// Keep this for a few releases for upgrade handling
-	// from versions where VMI-level hotplug was being done
+	if !vmGone {
+		removedFromVM, err := c.virtClient.EnsureVolumeRemovedVM(ctx, c.infraClusterNamespace, vmName, dvName)
+		if err != nil {
+			return false, err
+		}
+		if !removedFromVM {
+			return true, nil
+		}
+	}
+
+	removedFromVMI, err := c.virtClient.EnsureVolumeRemovedVMI(ctx, c.infraClusterNamespace, vmName, dvName)
+	if err != nil {
+		return false, err
+	}
+	return !removedFromVMI, nil
+}
+
+func (c *ControllerService) removeVolumeFromVm(ctx context.Context, dvName, vmName string) error {
+	vm, err := c.virtClient.GetWorkloadManagingVirtualMachine(ctx, c.infraClusterNamespace, vmName)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if vm != nil {
+		removePossibleVM := false
+		for _, volume := range vm.Spec.Template.Spec.Volumes {
+			if volume.DataVolume == nil {
+				continue
+			}
+			if volume.DataVolume.Hotpluggable && volume.Name == dvName {
+				removePossibleVM = true
+			}
+		}
+		if removePossibleVM {
+			// Detach DataVolume from VM
+			err = c.virtClient.RemoveVolumeFromVM(ctx, c.infraClusterNamespace, vmName, &kubevirtv1.RemoveVolumeOptions{Name: dvName})
+			if err != nil {
+				return err
+			}
+			// We're done
+			return nil
+		}
+	}
+
+	// VM is missing, or volume is no longer in VM.spec — check VMI status.
+	// This handles two cases:
+	//   1) Upgrade carry-over from versions that only hot-plugged at the VMI
+	//      level (pre-VM-hotplug).
+	//   2) VM teardown races where the VM object is deleted before the VMI
+	//      finishes terminating; the hot-plug pod is still active and must
+	//      be released to free the infra-side storage attachment.
 	vmi, err := c.virtClient.GetVirtualMachine(ctx, c.infraClusterNamespace, vmName)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// Both VM and VMI are gone — truly vacuous success.
+			klog.V(3).Infof("VM and VMI %s/%s both gone, considering volume %s detached", c.infraClusterNamespace, vmName, dvName)
+			return nil
+		}
 		return err
 	}
 	removePossibleVMI := false

--- a/pkg/service/controller_test.go
+++ b/pkg/service/controller_test.go
@@ -382,6 +382,27 @@ var _ = Describe("PublishUnPublish", func() {
 		Expect(capturingClient.hotunplugForVMIOccured).To(BeTrue())
 	})
 
+	It("should detach from VMI when the parent VM is gone but the VMI still has the hot-plug", func() {
+		// This simulates a CAPI/CAPK teardown race where the managing VM
+		// object is deleted before the VMI (and its hot-plug pod) finishes
+		// terminating. Pre-fix the driver returned success without calling
+		// RemoveVolumeFromVMI, leaving the hot-plug pod alive and the infra
+		// storage device exclusively attached to the source host.
+		capturingClient := &vmiUnplugCapturingClient{
+			ControllerClientMock: client,
+		}
+		controller.virtClient = capturingClient
+		capturingClient.ShouldReturnVMNotFound = true
+		capturingClient.virtualMachineStatus.VolumeStatus = []kubevirtv1.VolumeStatus{{
+			Name:          testVolumeName,
+			HotplugVolume: &kubevirtv1.HotplugVolumeStatus{},
+		}}
+
+		_, err := controller.ControllerUnpublishVolume(context.TODO(), getUnpublishVolumeRequest())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(capturingClient.hotunplugForVMIOccured).To(BeTrue(), "RemoveVolumeFromVMI must be invoked when VM is gone but VMI still has the hot-plug")
+	})
+
 	Context("Multi-attach", func() {
 
 		BeforeEach(func() {
@@ -1134,6 +1155,10 @@ func (c *ControllerClientMock) EnsureVolumeRemovedVM(_ context.Context, namespac
 	return false, nil
 }
 
+func (c *ControllerClientMock) EnsureVolumeRemovedVMI(_ context.Context, namespace, vmName, volName string) (bool, error) {
+	return false, nil
+}
+
 func (c *ControllerClientMock) CreateVolumeSnapshot(ctx context.Context, namespace, name, claimName, snapshotClassName string) (*snapshotv1.VolumeSnapshot, error) {
 	if c.FailCreateSnapshot {
 		return nil, errors.New("CreateVolumeSnapshot failed")
@@ -1288,8 +1313,9 @@ func (c *attachSkipClient) EnsureVolumeAvailableVM(_ context.Context,
 
 type detachSkipClient struct {
 	*ControllerClientMock
-	removeCnt int // RemoveVolumeFromVM called
-	ensureCnt int // EnsureVolumeRemoved(VM) called
+	removeCnt    int // RemoveVolumeFromVM called
+	ensureCnt    int // EnsureVolumeRemovedVM called
+	ensureVMICnt int // EnsureVolumeRemovedVMI called
 }
 
 func (c *detachSkipClient) RemoveVolumeFromVM(_ context.Context,
@@ -1303,5 +1329,12 @@ func (c *detachSkipClient) EnsureVolumeRemovedVM(_ context.Context,
 	ns, vm, dv string) (bool, error) {
 
 	c.ensureCnt++
-	return true, nil // volume absent
+	return true, nil // volume absent from VM spec
+}
+
+func (c *detachSkipClient) EnsureVolumeRemovedVMI(_ context.Context,
+	ns, vm, dv string) (bool, error) {
+
+	c.ensureVMICnt++
+	return true, nil // volume absent from VMI status
 }

--- a/sanity/sanity_test.go
+++ b/sanity/sanity_test.go
@@ -217,6 +217,10 @@ func (c *fakeKubeVirtClient) EnsureVolumeRemovedVM(_ context.Context, namespace,
 	return false, nil
 }
 
+func (c *fakeKubeVirtClient) EnsureVolumeRemovedVMI(_ context.Context, namespace, vmName, volName string) (bool, error) {
+	return false, nil
+}
+
 func (k *fakeKubeVirtClient) EnsureVolumeRemoved(_ context.Context, namespace, vmName, volumeName string, timeout time.Duration) error {
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

`ControllerUnpublishVolume` currently returns success as soon as the parent `VirtualMachine` object is missing, on the assumption that a missing VM means the hot-plug is already gone. In practice the VMI (and its hot-plug pod) can outlive the parent VM during a CAPI/CAPK teardown race — the infra-side storage device then stays exclusively attached to the source host, and the next attempt to attach the same volume to a different VM fails with `Multi-Attach error` or, on backends like DRBD that enforce exclusive attachment, with `failed to set source device readwrite`.

The same divergence appears when virt-api updates `VM.spec` optimistically on a `removevolume` call but virt-handler has not yet unplugged the QEMU device.

This PR:

- Adds `EnsureVolumeRemovedVMI` to the `kubevirt.Client` interface, mirroring the existing `EnsureVolumeRemovedVM` but inspecting `VMI.status.volumeStatus` instead of `VM.spec.template.spec.volumes`.
- Replaces the `VM not found = success` short-circuit in `ControllerUnpublishVolume` with a new `volumeStillAttached` helper that consults both surfaces. The original #119 unblock is preserved (the call still succeeds when the volume is genuinely gone from both); the new behaviour is that we now actually detach from the VMI when it still holds the hot-plug.
- Refactors `removeVolumeFromVm` so that it falls through to `RemoveVolumeFromVMI` when the parent VM is gone but the VMI still reports the hot-plug, closing the orphan path end-to-end.
- Adds a regression test in `controller_test.go` that covers the "VM gone but VMI still has the hot-plug" path.

We hit the bug 12 times across two tenant clusters in a single day before opening the linked issue. Full failure-mode catalogue and reproducer are in the issue.

**Which issue(s) this PR fixes**:

Fixes #182
Refs #83 #119 #134

**Special notes for your reviewer**:

- This changes behaviour: a "VM not found" no longer means "detach succeeded". For existing deployments that have already lost the VM object and only have the orphan VMI left, `ControllerUnpublishVolume` will now actually run `RemoveVolumeFromVMI` against the VMI — i.e. it will do the right thing instead of silently doing nothing. There is no CSI/API-surface change.
- I added one method (`EnsureVolumeRemovedVMI`) to the `kubevirt.Client` interface. I did **not** update `pkg/kubevirt/mocked_client.go`: the file is already stale relative to the interface (missing `EnsureVolumeRemovedVM` and `EnsureVolumeAvailableVM` among others) and `make mockgen` produces a much larger diff than the orphan-volume fix justifies. A separate "regen mocks" PR would be the right home for that. The hand-written test fakes (`ControllerClientMock` in `pkg/service/controller_test.go` and `fakeKubeVirtClient` in `sanity/sanity_test.go`) are updated.
- A companion PR (#185, separate and independent) introduces an opt-in `DetachReconciler` to catch orphans this synchronous path cannot reach (external-attacher giving up after force-detach timeout, VMIs in mid-migration, legacy state accumulated before this fix). They can be reviewed and merged in any order.

**Release note**:
```release-note
BugFix: ControllerUnpublishVolume no longer treats a missing parent VirtualMachine as "detach succeeded" — it now also checks the VMI status and detaches the hot-plug from the VMI if one is still attached, preventing orphan hot-plug pods that pin the infra storage device exclusively to the source host.
```
